### PR TITLE
chore: bump version to 0.1.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.1.0-rc.1",
+      "version": "0.1.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@cursor/sdk": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Publish the opencode integration fixes from PR #8 as rc.2.