### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-06-11
+
 - **More Cursor tools map onto opencode's native tool renderers (blocks mode).**
   Following the `edit` → diff-viewer mapping, Cursor's `shell`, `read`, `write`,
   `glob`, `grep`, `ls`, `updateTodos`, and `task` tool activity is now surfaced

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.1.0-rc.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.1.0-rc.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@cursor/sdk": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Release v0.2.0.

- Bump package.json + package-lock.json to 0.2.0
- Changelog entry for 0.2.0 (more Cursor tools mapped onto opencode native renderers; cleaner fallback blocks)

Merging this then pushing the \`v0.2.0\` tag triggers the npm publish + GitHub Release workflow.