### PR TITLE
chore: release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What's changed since v0.2.0

- feat: fingerprint-guarded session reuse as default (`session: "auto"`) (#18)
- fix(deps): patch transitive dependabot vulnerabilities via overrides (#16)
- docs: remove Serena-specific references, keep MCP forwarding generic (#17)

Minor bump (0.2.0 → 0.3.0) per semver: one new feature.