### PR TITLE
feat(grep): add distinguishing title to grep and glob tool blocks

### DIFF
--- a/src/provider/stream-map.ts
+++ b/src/provider/stream-map.ts
@@ -361,15 +361,17 @@ const NATIVE_ADAPTERS: Record<string, NativeToolAdapter> = {
 			const dir = strField(args, "targetDirectory");
 			return dir ? { pattern, path: dir } : { pattern };
 		},
-		result: (value) => {
+		result: (value, args) => {
 			if (!isRecord(value) || !Array.isArray(value["files"])) return null;
 			const files = (value["files"] as unknown[]).filter(
 				(f): f is string => typeof f === "string",
 			);
 			const truncated =
 				value["clientTruncated"] === true || value["ripgrepTruncated"] === true;
+			const pattern = strField(args, "globPattern") ?? "";
+			const dir = strField(args, "targetDirectory");
 			return {
-				title: "",
+				title: dir ? `${pattern} in ${dir}` : pattern,
 				metadata: { count: files.length, truncated },
 				output: files.length > 0 ? files.join("\n") : "No files found",
 			};
@@ -388,7 +390,7 @@ const NATIVE_ADAPTERS: Record<string, NativeToolAdapter> = {
 			if (g) out["include"] = g;
 			return out;
 		},
-		result: (value) => {
+		result: (value, args) => {
 			if (!isRecord(value)) return null;
 			const unions: unknown[] = [];
 			const ws = value["workspaceResults"];
@@ -434,8 +436,14 @@ const NATIVE_ADAPTERS: Record<string, NativeToolAdapter> = {
 					}
 				}
 			}
+			const pattern = strField(args, "pattern") ?? "";
+			const glob = strField(args, "glob");
+			const path = strField(args, "path");
+			let title = pattern;
+			if (glob) title += ` (${glob})`;
+			if (path) title += ` in ${path}`;
 			return {
-				title: "",
+				title,
 				metadata: { matches: total, truncated: false },
 				output:
 					total > 0

--- a/test/stream-map.test.ts
+++ b/test/stream-map.test.ts
@@ -939,6 +939,7 @@ describe("native tool mapping (blocks)", () => {
 			input: JSON.stringify({ pattern: "**/*.ts", path: "/src" }),
 		});
 		expect(foldedResult(result)).toMatchObject({
+			title: "**/*.ts in /src",
 			metadata: { count: 2, truncated: false },
 			output: "/src/a.ts\n/src/b.ts",
 		});
@@ -969,7 +970,10 @@ describe("native tool mapping (blocks)", () => {
 			toolName: "grep",
 			input: JSON.stringify({ pattern: "foo", path: "/src", include: "*.ts" }),
 		});
-		expect(foldedResult(result)).toMatchObject({ metadata: { matches: 1 } });
+		expect(foldedResult(result)).toMatchObject({
+			title: "foo (*.ts) in /src",
+			metadata: { matches: 1 },
+		});
 		expect(foldedResult(result).output).toContain("/src/a.ts:");
 		expect(foldedResult(result).output).toContain("Line 3: const foo = 1");
 	});


### PR DESCRIPTION
## Summary

- `grep` tool block now shows `pattern (include) in path` (e.g. `foo (*.ts) in /src`)
- `glob` tool block now shows `pattern in dir` (e.g. `**/*.ts in /src`)
- Previously both hardcoded `title: ""`, making multiple concurrent calls visually identical in opencode's tool blocks

## Changes

Both `result` signatures updated from `(value)` to `(value, args)` to access call args — the interface already supported this, no interface changes needed.

## Test Plan
- [x] Updated `stream-map.test.ts` to assert new titles
- [x] All 44 tests pass