### PR TITLE
fix(deps): add missing @connectrpc/connect-node for @cursor/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
+        "@connectrpc/connect-node": "^1.6.1",
         "@cursor/sdk": "^1.0.18",
         "@opencode-ai/plugin": "^1.17.7"
       },
@@ -53,6 +54,22 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
       }
     },
     "node_modules/@connectrpc/connect-web": {
@@ -2987,6 +3004,15 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.24.6",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prepublishOnly": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
+    "@connectrpc/connect-node": "^1.6.1",
     "@cursor/sdk": "^1.0.18",
     "@opencode-ai/plugin": "^1.17.7"
   },


### PR DESCRIPTION
## Problem
Plugin fails to load with:
```
Cannot find package '@connectrpc/connect-node' imported from .../@cursor/sdk/dist/esm/index.js
```

`@cursor/sdk@1.0.19` imports `@connectrpc/connect-node` at runtime (`Http2SessionManager`, `createNodeHttpClient`, `compressionGzip`) but only declares `@connectrpc/connect` and `@connectrpc/connect-web` in its dependencies — an upstream packaging bug. Node throws `ERR_MODULE_NOT_FOUND` on import.

## Fix
Add `@connectrpc/connect-node` as a direct dependency so the import resolves.

- Pinned to `^1.6.1` (resolves to `1.7.0`, the highest v1).
- **Not** v2.x: the SDK bundles `@connectrpc/connect@1.6.1`, and connect-node v2.x targets the connect v2.x API. v1 is required for compatibility.

## Verification
- `npm run typecheck` — clean
- `npm test` — 181/181 pass
- `npm run build` — success
- `import('@cursor/sdk')` resolves cleanly