### PR TITLE
fix(variants): drop redundant thinking variant when effort enum present

### DIFF
--- a/src/model-variants.ts
+++ b/src/model-variants.ts
@@ -58,6 +58,17 @@ export function buildModelVariants(item: ModelListItem): Record<string, CursorVa
   // reasoning variant so picking a reasoning level never re-enables fast.
   const defaults = defaultModelParams(item);
 
+  // Pre-pass: does any reasoning param expose a non-boolean effort enum (e.g.
+  // ["low","medium","high","xhigh","max"])? When it does, a coexisting boolean
+  // reasoning toggle (Cursor's `thinking=["false","true"]` on claude-* models)
+  // is redundant — selecting any effort level already enables reasoning — and
+  // surfacing it would add a stray `thinking` variant the standard opencode
+  // providers don't show. Suppress the boolean variant for parity. Order-
+  // independent: the enum may be declared before or after the boolean.
+  const hasEffortEnum = (item.parameters ?? []).some(
+    (p) => REASONING_PARAM.test(p.id) && !isBooleanParam(paramValues(p)) && paramValues(p).length > 0,
+  );
+
   for (const param of item.parameters ?? []) {
     const values = paramValues(param);
     if (values.length === 0) continue;
@@ -68,8 +79,9 @@ export function buildModelVariants(item: ModelListItem): Record<string, CursorVa
         // Boolean toggle (e.g. thinking=["false","true"]). Literal true/false
         // variant names are meaningless in the picker — surface a single
         // variant named after the param that switches it on. "Off" is the
-        // model's default (no variant selected).
-        if (values.includes("true")) {
+        // model's default (no variant selected). Skipped entirely when an
+        // effort enum coexists (see hasEffortEnum above).
+        if (!hasEffortEnum && values.includes("true")) {
           out[param.id.toLowerCase()] = { params: { ...defaults, [param.id]: "true" } };
         }
         continue;

--- a/test/model-variants.test.ts
+++ b/test/model-variants.test.ts
@@ -27,7 +27,11 @@ describe("buildModelVariants", () => {
     });
   });
 
-  it("combines boolean thinking with enum effort (claude catalog shape)", () => {
+  it("drops the boolean thinking variant when an effort enum is present (claude catalog shape)", () => {
+    // Cursor's claude-* catalog exposes BOTH a boolean `thinking` toggle and an
+    // effort enum. Selecting any effort level already enables reasoning, so the
+    // standalone `thinking` variant is redundant — and surfacing it would add a
+    // stray entry the standard opencode providers (effort-only) never show.
     const variants = buildModelVariants(
       model([
         { id: "thinking", values: [{ value: "false" }, { value: "true" }] },
@@ -35,9 +39,82 @@ describe("buildModelVariants", () => {
       ]),
     );
     expect(variants).toEqual({
-      thinking: { params: { thinking: "true" } },
       low: { params: { effort: "low" } },
       max: { params: { effort: "max" } },
+    });
+  });
+
+  it("suppresses the boolean thinking variant regardless of param order", () => {
+    // Order-independence guard for the hasEffortEnum pre-pass: the effort enum
+    // declared AFTER the boolean must still suppress it, and vice versa.
+    const enumFirst = buildModelVariants(
+      model([
+        { id: "effort", values: [{ value: "low" }, { value: "max" }] },
+        { id: "thinking", values: [{ value: "false" }, { value: "true" }] },
+      ]),
+    );
+    expect(enumFirst).toEqual({
+      low: { params: { effort: "low" } },
+      max: { params: { effort: "max" } },
+    });
+  });
+
+  it("composes suppression with fast defaults (production claude-via-Cursor shape)", () => {
+    // The real catalog model: boolean `thinking` + effort enum + `fast`. The
+    // `thinking` variant is suppressed, each effort variant bakes `fast` OFF
+    // (defaultModelParams), and a standalone `fast` opt-in still surfaces.
+    const variants = buildModelVariants(
+      model([
+        { id: "thinking", values: [{ value: "false" }, { value: "true" }] },
+        { id: "effort", values: [{ value: "low" }, { value: "high" }] },
+        { id: "fast", values: [{ value: "false" }, { value: "true" }] },
+      ]),
+    );
+    expect(variants).toEqual({
+      low: { params: { effort: "low", fast: "false" } },
+      high: { params: { effort: "high", fast: "false" } },
+      fast: { params: { fast: "true" } },
+    });
+  });
+
+  it("does not suppress the boolean thinking variant for a zero-value effort enum", () => {
+    // hasEffortEnum requires a non-empty enum; an effort param with no values
+    // must not count as an enum, so the boolean `thinking` variant survives.
+    const variants = buildModelVariants(
+      model([
+        { id: "thinking", values: [{ value: "false" }, { value: "true" }] },
+        { id: "effort", values: [] },
+      ]),
+    );
+    expect(variants).toEqual({ thinking: { params: { thinking: "true" } } });
+  });
+
+  it("does not emit a thinking variant when the boolean lacks a 'true' value", () => {
+    // Boolean `thinking=["false"]` has nothing to opt INTO; combined with an
+    // effort enum the result is purely the effort variants.
+    const variants = buildModelVariants(
+      model([
+        { id: "thinking", values: [{ value: "false" }] },
+        { id: "effort", values: [{ value: "low" }] },
+      ]),
+    );
+    expect(variants).toEqual({ low: { params: { effort: "low" } } });
+  });
+
+  it("pins current behavior for a mixed boolean+enum reasoning param", () => {
+    // A single reasoning param mixing boolean sentinels with effort values is
+    // classified non-boolean (isBooleanParam requires EVERY value be a sentinel),
+    // so it flows through the enum branch and emits literal false/true variants.
+    // Not a real catalog shape today; pinned so a future change is caught.
+    const variants = buildModelVariants(
+      model([
+        { id: "reasoning", values: [{ value: "false" }, { value: "true" }, { value: "high" }] },
+      ]),
+    );
+    expect(variants).toEqual({
+      false: { params: { reasoning: "false" } },
+      true: { params: { reasoning: "true" } },
+      high: { params: { reasoning: "high" } },
     });
   });
 


### PR DESCRIPTION
## Problem

For Anthropic/Claude models accessed via the Cursor provider, the Cursor SDK catalog exposes **two** reasoning params on the same model:

- a boolean `thinking` = `["false","true"]`
- an effort enum, e.g. `["low","medium","high","xhigh","max"]`

`buildModelVariants` emitted a variant for each, so opencode's variant cycler showed:

> `thinking`  +  `low / medium / high / xhigh / max`

Standard opencode providers (driven by models.dev `reasoning_options` of type `effort`) show **only** the five effort levels — no `thinking` entry. The extra `thinking` variant was inconsistent and redundant (selecting any effort level already enables reasoning).

## Fix

`buildModelVariants` (`src/model-variants.ts`):

- Added a `hasEffortEnum` pre-pass — scans params for any non-boolean reasoning enum, order-independent.
- Guarded the boolean reasoning branch: when `hasEffortEnum` is true, skip emitting the param-named boolean variant.
- Effort variants are unchanged — **no `thinking:"true"` baked in** (effort alone enables reasoning, per design decision).

## Behavior matrix

| Model param shape | Before | After |
|-------------------|--------|-------|
| boolean `thinking` + effort enum (Claude via Cursor) | `thinking` + `low/…/max` | `low/…/max` ✅ parity |
| boolean `thinking` only (no enum) | `thinking` | `thinking` (unchanged) |
| effort enum only | effort levels | effort levels (unchanged) |
| `fast` toggle | `fast` opt-in + baked-off defaults | unchanged |

Out of scope: `composer-2.5` `thinking=["off","on"]` (treated as enum), `fast`, `defaultModelParams`.

## Tests

Updated the former dual-param test and added 4 new cases in `test/model-variants.test.ts`:

1. **Production claude-via-Cursor shape** — `thinking` + `effort` + `fast`: asserts `thinking` suppressed, `fast:"false"` baked into effort variants, `fast` opt-in present.
2. **Order-independence** — effort enum declared after boolean still suppresses it.
3. **Zero-value effort enum guard** — empty enum does not count; boolean `thinking` survives.
4. **Boolean without `true`** — `thinking=["false"]` + effort → only effort variants.
5. **Mixed boolean+enum param pinned** — `["false","true","high"]` current behavior pinned so a future catalog change is caught.

## Verification

- `npx vitest run` → **190 passed (18 files)**
- `npx tsc --noEmit` → exit 0

## Review

Reviewed by `code-reviewer` agent: no critical issues, fix correct for all real catalog shapes. Tests added in response to its findings (production-shape+fast composition, zero-value-enum guard).

Supersedes #42 (closed when its head branch was renamed).