### PR TITLE
chore(deps): consolidate npm dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
-        "@connectrpc/connect-node": "^1.6.1",
-        "@cursor/sdk": "^1.0.18",
-        "@opencode-ai/plugin": "^1.17.7"
+        "@connectrpc/connect-node": "^2.1.2",
+        "@cursor/sdk": "^1.0.20",
+        "@opencode-ai/plugin": "^1.17.9"
       },
       "devDependencies": {
         "@ai-sdk/provider": "^3.0.10",
-        "@opencode-ai/sdk": "^1.17.1",
-        "@types/node": "^25.9.2",
+        "@opencode-ai/sdk": "^1.17.9",
+        "@types/node": "^26.0.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
@@ -42,12 +42,146 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.21.tgz",
+      "integrity": "sha512-dPBBz+5VMaR+3lbYbWFn/JLXEwCwD2LP0ara/bYMVDJBiEJZodYI+pUPJkZDCVcThp/NybCR1EQO0RBDNE6WWQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@connectrpc/connect-web": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.21",
+        "@cursor/sdk-darwin-x64": "1.0.21",
+        "@cursor/sdk-linux-arm64": "1.0.21",
+        "@cursor/sdk-linux-x64": "1.0.21",
+        "@cursor/sdk-win32-x64": "1.0.21"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.21.tgz",
+      "integrity": "sha512-TFrSEPu4mE+MM0W5qj0EL1KWBnwJ4A/VChOzaa6fup6NU7p51W33Ymnvrr728qVqtYfIylxa0iMUSDx/zfaCgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.21.tgz",
+      "integrity": "sha512-yKPR/zPpU+3T3y5oB6YmzgZbKCEDdNQjKSbLedZhlXnCK4gTIocci4BxCkLugELwpttOdSdHq1eqbzJvOnMFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.21.tgz",
+      "integrity": "sha512-HVD65tMKh0nFihpfjIKTpHwQL9poboMrXq7mEg5uThuMMJ8zsvUdFgah+Tr6mWfDyNwC1/Y6b7U5KpP5rhRqyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.21.tgz",
+      "integrity": "sha512-r42N9mBhPTRbTHQC/uMI3ykKD0rIOurB5x7el3qSyZ8UKT0doDdVbh98Hcvl6Y+CJWGE37fLbF0f5sVbofjSGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.21.tgz",
+      "integrity": "sha512-BrJDNncxNGBRnWsY5SPM4RfVy/fuF+hglHVWCVZvIpyuwlonTwm+VtISo1KEY86/BXRNpfBKffHBKmcv+opPYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "rg": "bin/rg.exe"
+      }
+    },
+    "node_modules/@cursor/sdk/node_modules/@bufbuild/protobuf": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
       "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
-    "node_modules/@connectrpc/connect": {
+    "node_modules/@cursor/sdk/node_modules/@connectrpc/connect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
       "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
@@ -56,7 +190,7 @@
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
-    "node_modules/@connectrpc/connect-node": {
+    "node_modules/@cursor/sdk/node_modules/@connectrpc/connect-node": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
       "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
@@ -72,7 +206,7 @@
         "@connectrpc/connect": "1.7.0"
       }
     },
-    "node_modules/@connectrpc/connect-web": {
+    "node_modules/@cursor/sdk/node_modules/@connectrpc/connect-web": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
       "integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
@@ -80,109 +214,6 @@
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0",
         "@connectrpc/connect": "1.7.0"
-      }
-    },
-    "node_modules/@cursor/sdk": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.19.tgz",
-      "integrity": "sha512-DJbVnGeRJq7iwt9mz1cMACqVfAYP15IB+Q8Iz2eDtEN4A8Dp83yB0Y31YREj1jeA9EPUEdRZJRIYch/s+Wi9Ow==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@bufbuild/protobuf": "1.10.0",
-        "@connectrpc/connect": "^1.6.1",
-        "@connectrpc/connect-web": "^1.6.1",
-        "@statsig/js-client": "3.31.0",
-        "zod": "^3.25.0"
-      },
-      "engines": {
-        "node": ">=22.13"
-      },
-      "optionalDependencies": {
-        "@cursor/sdk-darwin-arm64": "1.0.19",
-        "@cursor/sdk-darwin-x64": "1.0.19",
-        "@cursor/sdk-linux-arm64": "1.0.19",
-        "@cursor/sdk-linux-x64": "1.0.19",
-        "@cursor/sdk-win32-x64": "1.0.19"
-      }
-    },
-    "node_modules/@cursor/sdk-darwin-arm64": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.19.tgz",
-      "integrity": "sha512-CPhqcpDaqjjqkkVGMLsdfXv7PGznL5L6U5CJXps/oaGW5mtHoxDpsRNj1rszCRQXNAvmMU+EFxLWnBwlE8mUNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "rg": "bin/rg"
-      }
-    },
-    "node_modules/@cursor/sdk-darwin-x64": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.19.tgz",
-      "integrity": "sha512-6/Jj0hxrxEs9V9wtYEApSkMcJwYAaT4Vwna9xBzgN6CK1K4Ws0E1/PfiddahAAFZpkp9pgjb8wQXwG7qJ2g77A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "rg": "bin/rg"
-      }
-    },
-    "node_modules/@cursor/sdk-linux-arm64": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.19.tgz",
-      "integrity": "sha512-Dq/BhGT1jAZ6eHJwy1Vugi/Upc+yoL0X/LN6ppd9cVPM9OAB1xX5KIbvIwsGlNiZccPLVXFv/1KOp5SBK+y+jQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "rg": "bin/rg"
-      }
-    },
-    "node_modules/@cursor/sdk-linux-x64": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.19.tgz",
-      "integrity": "sha512-ZHgHH+SdEwYwfPg/uVKqZRVOIMCV3/3vghxc/usOMYMrhbY9TYXZxYqwWTduVLzCXH7Dz0aT19mSJHmhwkQ1CA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "rg": "bin/rg"
-      }
-    },
-    "node_modules/@cursor/sdk-win32-x64": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.19.tgz",
-      "integrity": "sha512-XGIQmx3J0K8uKkA00qnoy1FJHFdFdwNdcmUqtRF1PXLcYup91YYetAHk9afXM7S/v1t0L4EatydsirL8uz7SIw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "bin": {
-        "rg": "bin/rg.exe"
       }
     },
     "node_modules/@emnapi/core": {
@@ -798,12 +829,12 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.7.tgz",
-      "integrity": "sha512-/MXRdz5z5tDySwMM4v02cN0om1QgALyE8FTXFU93zKV4I/oW5a0IjQ7dK8Iue3NpRc9e5UHhgO5ELeNLqnpWPA==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.9.tgz",
+      "integrity": "sha512-RvYsX2k90ew0P3c0R/Jrt6UOdA5CYf4GmYuREDKHx31GSJ25WKg9hrTzkcwCfvPPCpaBc53Qq6Fon9aWr+58ag==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.17.7",
+        "@opencode-ai/sdk": "1.17.9",
         "effect": "4.0.0-beta.74",
         "zod": "4.1.8"
       },
@@ -834,9 +865,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.7.tgz",
-      "integrity": "sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.9.tgz",
+      "integrity": "sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -1581,13 +1612,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -3015,9 +3046,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "prepublishOnly": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
-    "@connectrpc/connect-node": "^1.6.1",
-    "@cursor/sdk": "^1.0.18",
-    "@opencode-ai/plugin": "^1.17.7"
+    "@connectrpc/connect-node": "^2.1.2",
+    "@cursor/sdk": "^1.0.20",
+    "@opencode-ai/plugin": "^1.17.9"
   },
   "overrides": {
     "undici": "^6.24.0",
@@ -69,8 +69,8 @@
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.10",
-    "@opencode-ai/sdk": "^1.17.1",
-    "@types/node": "^25.9.2",
+    "@opencode-ai/sdk": "^1.17.9",
+    "@types/node": "^26.0.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"


### PR DESCRIPTION
Consolidates 4 Dependabot PRs into a single update:

- #39: @connectrpc/connect-node 1.7.0 → 2.1.2 (major)
- #41: @cursor/sdk 1.0.19 → 1.0.20
- #40: @opencode-ai/plugin 1.17.7 → 1.17.9
- #38: @opencode-ai/sdk 1.17.7 → 1.17.9, @types/node 25.9.3 → 26.0.0 (major)

All four touch package-lock.json and conflict on sequential merge. This PR applies them together.

Verified: typecheck clean, 185/185 tests pass.

Supersedes: #38 #39 #40 #41