### PR TITLE
chore(dependabot): group @opencode-ai/* packages together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
+      opencode-ai:
+        patterns:
+          - "@opencode-ai/*"
       dev-dependencies:
         dependency-type: "development"
 


### PR DESCRIPTION
## Problem

`@opencode-ai/plugin` (production dependency) and `@opencode-ai/sdk` (devDependency) are sibling packages that version-lock upstream. Dependabot currently splits them across separate group buckets — `plugin` gets an individual PR and `sdk` lands in the `dev-dependencies` group PR. This causes version drift if merged sequentially.

## Fix

Add explicit pattern group `@opencode-ai/*` to the npm ecosystem config. Listed **before** `dev-dependencies` so it takes precedence (Dependabot assigns packages to the first matching group).

```yaml
groups:
  opencode-ai:
    patterns:
      - "@opencode-ai/*"
  dev-dependencies:
    dependency-type: "development"
```

Result: `@opencode-ai/plugin` and `@opencode-ai/sdk` will land in a single PR going forward, keeping them version-synced. Other devDependencies continue grouping separately.