### PR TITLE
chore(release): 0.4.4-next.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **Fixed: redundant `thinking` variant removed for effort-enum models.** When a
+  Cursor catalog model exposes both a boolean `thinking` toggle and an effort
+  enum (e.g. Claude models exposing `thinking=["false","true"]` alongside
+  `["low","medium","high","xhigh","max"]`), the variant picker showed a stray
+  `thinking` entry in addition to the effort levels. Standard opencode providers
+  (driven by models.dev `reasoning_options` of type `effort`) surface only the
+  five effort levels, so the extra entry broke parity and was redundant —
+  selecting any effort level already enables reasoning. The boolean `thinking`
+  variant is now suppressed whenever a non-boolean reasoning enum is present on
+  the same model. Models whose only reasoning control is the boolean toggle
+  still surface the single `thinking` variant; the `fast` toggle and its baked-
+  off default are unchanged.
+
 - **Fixed: Cursor's `fast` tier is no longer silently forced on.** The variant
   builder only mapped reasoning/effort params and dropped Cursor's `fast` toggle
   entirely, so it never reached `providerOptions.cursor`. Because Cursor marks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.3",
+  "version": "0.4.4-next.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.4.3",
+      "version": "0.4.4-next.0",
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.3",
+  "version": "0.4.4-next.0",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Lands the version bump and CHANGELOG entry for the `@next` prerelease.

## Why a PR?

Direct push to `main` is blocked by the repo's branch-protection rule (changes must go through a PR). The `v0.4.4-next.0` tag was pushed and the [Release workflow](https://github.com/stablekernel/opencode-cursor/actions/runs/28112319705) already published `@stablekernel/opencode-cursor@0.4.4-next.0` to the `next` dist-tag — but the version-bump commit (`0.4.4-next.0`) and the CHANGELOG entry only exist locally. This PR lands them on `main` so the published version and `main`'s `package.json` agree.

## Contents

- `package.json` version → `0.4.4-next.0` (the bump `npm version prerelease --preid=next` made; tag `v0.4.4-next.0` already pushed)
- `CHANGELOG.md`: new `[Unreleased]` entry for the thinking-variant fix shipped in this prerelease (#43)

## Verification

- Release workflow run #28112319705 — all steps green (typecheck, test, build, integration smoke test, npm publish to `next`, GitHub prerelease created)
- `npm view @stablekernel/opencode-cursor dist-tags` → `next: 0.4.4-next.0`

Merge target: `main`. This only adds the version bump + changelog; no code changes.