### PR TITLE
fix(variants): normalize enum keys and drop 'none' for provider parity

### DIFF
--- a/src/model-variants.ts
+++ b/src/model-variants.ts
@@ -88,9 +88,19 @@ export function buildModelVariants(item: ModelListItem): Record<string, CursorVa
       }
 
       for (const value of values) {
-        // Key by the bare value (e.g. "high"); prefix with the param id only
-        // when two params share a value (e.g. reasoning-low vs effort-low).
-        const key = out[value] === undefined ? value : `${param.id}-${value}`;
+        // `none` means reasoning OFF — the model's default when no variant is
+        // selected. Surfacing it as a selectable variant is meaningless (you
+        // get it by picking nothing), so skip it. Standard providers
+        // (models.dev) include `none` in their effort values, but the
+        // no-variant-selected state already represents it.
+        if (value === "none") continue;
+        // Cursor labels the top reasoning tier "extra-high"; the opencode
+        // standard (models.dev) calls it "xhigh". Use the standard label for
+        // the variant key so the cycler is consistent across providers, but
+        // keep the Cursor wire-format value ("extra-high") in the params sent
+        // to the API.
+        const displayKey = value === "extra-high" ? "xhigh" : value;
+        const key = out[displayKey] === undefined ? displayKey : `${param.id}-${displayKey}`;
         out[key] = { params: { ...defaults, [param.id]: value } };
       }
       continue;

--- a/test/model-variants.test.ts
+++ b/test/model-variants.test.ts
@@ -131,6 +131,79 @@ describe("buildModelVariants", () => {
     });
   });
 
+  it("renames extra-high to xhigh in the variant key but keeps the wire value", () => {
+    // Cursor labels the top reasoning tier "extra-high"; the opencode standard
+    // (models.dev) calls it "xhigh". The variant KEY normalizes to xhigh so
+    // the cycler is consistent across providers; the param VALUE sent to
+    // Cursor's API stays "extra-high".
+    const variants = buildModelVariants(
+      model([{ id: "reasoning", values: [{ value: "low" }, { value: "extra-high" }] }]),
+    );
+    expect(variants).toEqual({
+      low: { params: { reasoning: "low" } },
+      xhigh: { params: { reasoning: "extra-high" } },
+    });
+  });
+
+  it("drops the 'none' reasoning value (it is the model default)", () => {
+    // `none` = reasoning OFF, which is what you get by selecting no variant.
+    // Surfacing it as a selectable entry is meaningless, so it is skipped.
+    const variants = buildModelVariants(
+      model([
+        { id: "reasoning", values: [{ value: "none" }, { value: "low" }, { value: "high" }] },
+      ]),
+    );
+    expect(variants).toEqual({
+      low: { params: { reasoning: "low" } },
+      high: { params: { reasoning: "high" } },
+    });
+  });
+
+  it("composes none-drop and extra-high rename for the real GPT shape", () => {
+    // gpt-5.5 / gpt-5.4 catalog: reasoning=[none,low,medium,high,extra-high]
+    // + fast. Expect: low, medium, high, xhigh (no none, extra-high→xhigh),
+    // each effort variant bakes fast OFF, plus a standalone fast opt-in.
+    const variants = buildModelVariants(
+      model([
+        {
+          id: "reasoning",
+          values: [
+            { value: "none" },
+            { value: "low" },
+            { value: "medium" },
+            { value: "high" },
+            { value: "extra-high" },
+          ],
+        },
+        { id: "fast", values: [{ value: "false" }, { value: "true" }] },
+      ]),
+    );
+    expect(variants).toEqual({
+      low: { params: { reasoning: "low", fast: "false" } },
+      medium: { params: { reasoning: "medium", fast: "false" } },
+      high: { params: { reasoning: "high", fast: "false" } },
+      xhigh: { params: { reasoning: "extra-high", fast: "false" } },
+      fast: { params: { fast: "true" } },
+    });
+  });
+
+  it("prefixes the display key on a collision involving extra-high", () => {
+    // Defensive: if two reasoning params both resolve to the xhigh display key
+    // (one via the real "xhigh" value, one via "extra-high"→xhigh), the second
+    // is prefixed with its param id. No current catalog model hits this, but
+    // the guard must hold.
+    const variants = buildModelVariants(
+      model([
+        { id: "effort", values: [{ value: "xhigh" }] },
+        { id: "reasoning", values: [{ value: "extra-high" }] },
+      ]),
+    );
+    expect(variants).toEqual({
+      xhigh: { params: { effort: "xhigh" } },
+      "reasoning-xhigh": { params: { reasoning: "extra-high" } },
+    });
+  });
+
   it("surfaces a non-reasoning boolean (fast) as an opt-in toggle; ignores enum context", () => {
     // `fast` is Cursor's fast-tier toggle. It is not a reasoning level, but the
     // user must be able to opt INTO it from the picker (default is off, sent


### PR DESCRIPTION
## Problem

Surveyed all 29 models in the real Cursor catalog (cached model discovery) and compared variant output against models.dev standard providers. Two mapping inconsistencies found on GPT models:

| Issue | Cursor | Standard (models.dev) |
|-------|--------|----------------------|
| Top-tier label | `extra-high` | `xhigh` |
| Reasoning-off value | `none` surfaced as a selectable variant | `none` = implicit default (no variant selected) |

## Fix

`buildModelVariants` enum reasoning branch (`src/model-variants.ts`):

1. **Skip `none`** — `none` = reasoning OFF = the model's default when no variant is selected. Surfacing it as a selectable entry is meaningless; it's dropped from the enum loop.
2. **Alias `extra-high` → `xhigh`** — the variant KEY normalizes to `xhigh` so the cycler label matches standard providers. The param VALUE sent to Cursor's API stays `extra-high` (Cursor's wire format, unchanged). Collision-prefix logic now uses the display key.

## Behavior matrix (after fix)

| Model | Before | After | Standard |
|-------|--------|-------|----------|
| gpt-5.5 | none, low, medium, high, extra-high, fast | low, medium, high, **xhigh**, fast | effort[none\|low\|medium\|high\|xhigh] + fast |
| gpt-5.4 | none, low, medium, high, extra-high, fast | low, medium, high, **xhigh**, fast | effort[none\|low\|medium\|high\|xhigh] + fast |
| gpt-5.3-codex | low, medium, high, extra-high, fast | low, medium, high, **xhigh**, fast | (not in models.dev) |
| gpt-5.4-mini | none, low, medium, high, xhigh | low, medium, high, xhigh | effort[none\|low\|medium\|high\|xhigh] |
| claude-opus-4-8 | low, medium, high, xhigh, max, fast | (unchanged) | effort[low\|medium\|high\|xhigh\|max] + fast |
| claude-opus-4-5 | thinking | (unchanged — bool-only) | effort[low\|medium\|high] + budget_tokens |

## Out of scope

- Boolean-only `thinking` models (no effort enum on Cursor; only reasoning control available) — unchanged
- `fast` toggle placement (UX/categorization concern, not a mapping bug) — unchanged
- `context` enum (intentionally unsupported; consistent with models.dev) — unchanged

## Tests

4 new tests in `test/model-variants.test.ts`:
1. `extra-high` → `xhigh` rename (key normalizes, wire value preserved)
2. `none` dropped from reasoning enum
3. Realistic GPT shape: `reasoning=[none,low,medium,high,extra-high]` + `fast` → `low, medium, high, xhigh, fast` with `fast:false` baked in
4. Collision guard: `effort=xhigh` + `reasoning=extra-high` → second prefixed `reasoning-xhigh`

## Verification

- `npx vitest run` → **194 passed (18 files)** (+4)
- `npx tsc --noEmit` → exit 0
- Catalog simulation across all 29 cached models: GPT models now show `xhigh` (not `extra-high`) and no `none`; Claude and boolean-only models unchanged