### PR TITLE
chore(release): 0.4.4-next.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.3",
+  "version": "0.4.4-next.1",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Pre-release cut targeting the two fixes merged since `v0.4.4-next.0`:

- #48 fix(variants): normalize enum keys and drop 'none' for provider parity
- #49 fix: installer failing on opencode.jsonc files with trailing commas

Bumps `package.json` → `0.4.4-next.1`. On merge, push the `v0.4.4-next.1` tag to trigger `release.yml` (publish to npm `next` dist-tag + GitHub pre-release, not `latest`).

Stable `0.4.4` stays manual.