### PR TITLE
chore(release): 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.4.5-next.0] — 2026-07-06
+## [0.4.5] — 2026-07-07
 
 - **Fixed: Cursor agent rejecting turns as "prompt injection" / "gaslighting."**
   The provider flattened opencode's system prompt into the user-message transcript;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.5-next.0",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.4.5-next.0",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.5-next.0",
+  "version": "0.4.5",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Promote `0.4.5-next.0` → stable `0.4.5`.

- Bump `package.json` + `package-lock.json` version → `0.4.5`
- Rename CHANGELOG `[0.4.5-next.0]` → `[0.4.5]` dated 2026-07-07
- No code changes since the prerelease (HEAD == v0.4.5-next.0)

Merge → tag `v0.4.5` → push triggers `.github/workflows/release.yml` (npm `latest` + GitHub Release marked latest).