### PR TITLE
chore(deps): consolidate dependabot updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",
-        "@cursor/sdk": "^1.0.20",
-        "@opencode-ai/plugin": "^1.17.9",
+        "@cursor/sdk": "^1.0.23",
+        "@opencode-ai/plugin": "^1.17.14",
         "semver": "^7.8.4"
       },
       "devDependencies": {
-        "@ai-sdk/provider": "^3.0.10",
-        "@opencode-ai/sdk": "^1.17.9",
+        "@ai-sdk/provider": "^3.0.13",
+        "@opencode-ai/sdk": "^1.17.14",
         "@types/node": "^26.0.0",
         "@types/semver": "^7.7.1",
         "tsup": "^8.5.1",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.13.tgz",
+      "integrity": "sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@cursor/sdk": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.21.tgz",
-      "integrity": "sha512-dPBBz+5VMaR+3lbYbWFn/JLXEwCwD2LP0ara/bYMVDJBiEJZodYI+pUPJkZDCVcThp/NybCR1EQO0RBDNE6WWQ==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.23.tgz",
+      "integrity": "sha512-VIh8oW89XXACUkQqB2N8TaU3A/y2jQieF++VC6QqIqKhKRKj7kd+pzeh43MXusuPpebtxtEzqvjaCLlc1xbYTQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bufbuild/protobuf": "1.10.0",
@@ -90,17 +90,17 @@
         "node": ">=22.13"
       },
       "optionalDependencies": {
-        "@cursor/sdk-darwin-arm64": "1.0.21",
-        "@cursor/sdk-darwin-x64": "1.0.21",
-        "@cursor/sdk-linux-arm64": "1.0.21",
-        "@cursor/sdk-linux-x64": "1.0.21",
-        "@cursor/sdk-win32-x64": "1.0.21"
+        "@cursor/sdk-darwin-arm64": "1.0.23",
+        "@cursor/sdk-darwin-x64": "1.0.23",
+        "@cursor/sdk-linux-arm64": "1.0.23",
+        "@cursor/sdk-linux-x64": "1.0.23",
+        "@cursor/sdk-win32-x64": "1.0.23"
       }
     },
     "node_modules/@cursor/sdk-darwin-arm64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.21.tgz",
-      "integrity": "sha512-TFrSEPu4mE+MM0W5qj0EL1KWBnwJ4A/VChOzaa6fup6NU7p51W33Ymnvrr728qVqtYfIylxa0iMUSDx/zfaCgg==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.23.tgz",
+      "integrity": "sha512-HpltGkIDFG+XgsETJho0OiOvGLyMKqZKhh4uXtD3ZKZcgTtLvKgbbU8jVgEMa3qodtfwPz5lpwAjs5jM1zOt6w==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@cursor/sdk-darwin-x64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.21.tgz",
-      "integrity": "sha512-yKPR/zPpU+3T3y5oB6YmzgZbKCEDdNQjKSbLedZhlXnCK4gTIocci4BxCkLugELwpttOdSdHq1eqbzJvOnMFmQ==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.23.tgz",
+      "integrity": "sha512-sjRQVhU7UL3kYSR9DzY+BAwa/iFdnPvTI3E62mIhj/2ey3LEnhIhotZQ9ymNJ0wA5BfhC7Be+JYcSMDyHxxr1g==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@cursor/sdk-linux-arm64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.21.tgz",
-      "integrity": "sha512-HVD65tMKh0nFihpfjIKTpHwQL9poboMrXq7mEg5uThuMMJ8zsvUdFgah+Tr6mWfDyNwC1/Y6b7U5KpP5rhRqyw==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.23.tgz",
+      "integrity": "sha512-RizTwZ2Hhhaq8bnF3yGUZWBUvLA+/lExlTAg/5Levc9f7hNoDZViIP3XaVWY/8yzPAxypeds8tWacVIaAA2/Ig==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@cursor/sdk-linux-x64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.21.tgz",
-      "integrity": "sha512-r42N9mBhPTRbTHQC/uMI3ykKD0rIOurB5x7el3qSyZ8UKT0doDdVbh98Hcvl6Y+CJWGE37fLbF0f5sVbofjSGw==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.23.tgz",
+      "integrity": "sha512-s93WBbi4hrE/uisTrEfNNH1m18bwfO6wmmsnIYQ3W3gbGBriFM1ZeroHxj1F6paMDE7o/dfUeW22lQ72rRZrSA==",
       "cpu": [
         "x64"
       ],
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@cursor/sdk-win32-x64": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.21.tgz",
-      "integrity": "sha512-BrJDNncxNGBRnWsY5SPM4RfVy/fuF+hglHVWCVZvIpyuwlonTwm+VtISo1KEY86/BXRNpfBKffHBKmcv+opPYg==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.23.tgz",
+      "integrity": "sha512-d1p1+tRJbNZTUqw8SPEW9OYtU02ynZysASDDvhpaEFtbPwGFUrez9sVbFHpbuXeOXL//H+faiHJanVFsUNfIZw==",
       "cpu": [
         "x64"
       ],
@@ -831,19 +831,20 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.9.tgz",
-      "integrity": "sha512-RvYsX2k90ew0P3c0R/Jrt6UOdA5CYf4GmYuREDKHx31GSJ25WKg9hrTzkcwCfvPPCpaBc53Qq6Fon9aWr+58ag==",
+      "version": "1.17.14",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.14.tgz",
+      "integrity": "sha512-upKf4QHZqjr2cqHJcJiGTUSGJFFVR26Nu8Y2QRThQ2NgXcQ44T1cRvI80nhK87wQsFcHPI842d+cPYERV+lB4w==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.17.9",
-        "effect": "4.0.0-beta.74",
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.17.14",
+        "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.3.4",
-        "@opentui/keymap": ">=0.3.4",
-        "@opentui/solid": ">=0.3.4"
+        "@opentui/core": ">=0.4.3",
+        "@opentui/keymap": ">=0.4.3",
+        "@opentui/solid": ">=0.4.3"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -857,6 +858,18 @@
         }
       }
     },
+    "node_modules/@opencode-ai/plugin/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@opencode-ai/plugin/node_modules/zod": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
@@ -867,9 +880,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.9.tgz",
-      "integrity": "sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==",
+      "version": "1.17.14",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.14.tgz",
+      "integrity": "sha512-ycSYSF0kuJmNUP38VYnsFEoUWPyjlLjAZFPtYuMt+32Tz+NqVsAPcqK3MPBRd5v+GChjAyApB/y56i7Ub08IAg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -1902,9 +1915,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.74",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
-      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -2090,7 +2103,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/kubernetes-types": {
@@ -2464,9 +2476,9 @@
       }
     },
     "node_modules/multipasta": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
-      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2670,9 +2682,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+      "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
       "funding": [
         {
           "type": "individual",
@@ -2950,9 +2962,9 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.2.tgz",
+      "integrity": "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -3074,9 +3086,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "dependencies": {
     "@connectrpc/connect-node": "^2.1.2",
-    "@cursor/sdk": "^1.0.20",
-    "@opencode-ai/plugin": "^1.17.9",
+    "@cursor/sdk": "^1.0.23",
+    "@opencode-ai/plugin": "^1.17.14",
     "semver": "^7.8.4"
   },
   "overrides": {
@@ -69,8 +69,8 @@
     "@ai-sdk/provider": "^3.0.0"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^3.0.10",
-    "@opencode-ai/sdk": "^1.17.9",
+    "@ai-sdk/provider": "^3.0.13",
+    "@opencode-ai/sdk": "^1.17.14",
     "@types/node": "^26.0.0",
     "@types/semver": "^7.7.1",
     "tsup": "^8.5.1",


### PR DESCRIPTION
Consolidates open Dependabot PRs #53, #55, #59.

## Changes
| Dep | From | To | Latest? |
|-----|------|-----|---------|
| `@cursor/sdk` | ^1.0.20 | ^1.0.23 | latest |
| `@opencode-ai/plugin` | ^1.17.9 | ^1.17.14 | latest |
| `@opencode-ai/sdk` | ^1.17.9 | ^1.17.14 | latest |
| `@ai-sdk/provider` | ^3.0.10 | ^3.0.13 | latest v3 |

## Deferred: `@ai-sdk/provider` v4 (part of #59)

PR #59 proposed bumping `@ai-sdk/provider` to `^4.0.2` (major). Verified this locally: typecheck and all 300 tests pass under v4 too, since it retains the `LanguageModelV3*`/`ProviderV3` types this codebase uses.

However, the opencode host ecosystem (`@opencode-ai/plugin@1.17.14`) still depends on `@ai-sdk/provider@3.0.8` at runtime, and this package declares `@ai-sdk/provider` as a `^3.0.0` peerDependency for the host to satisfy. Bumping the devDependency to v4 while the peerDep stays `^3.0.0` (and the real ecosystem runs v3) would decouple what's tested from what's shipped, for no functional gain right now. Staying on latest v3 (`^3.0.13`) keeps dev/test aligned with the runtime host.

Revisit once the opencode host ecosystem itself moves to `@ai-sdk/provider` v4.

## Verification
- `npm run typecheck`: clean
- `npm test`: 300/300 passed (26 files)

Closes #53, #55. Supersedes #59 (partial — see note above).