### PR TITLE
chore(release): 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.6] — 2026-07-08
+
+- **Fixed: newly released Cursor models didn't appear locally without a manual
+  refresh.** The auth loader warmed the model cache with a call that respected
+  the 24h on-disk TTL and no-opped while the cache was still fresh. It now
+  passes `forceRefresh: true`, so the catalog is force-refreshed via a live
+  `Cursor.models.list()` on every opencode startup (fire-and-forget, no added
+  latency); the `config` and `provider.models` hooks keep serving the existing
+  cache instantly (#65).
+
 ## [0.4.5] — 2026-07-07
 
 - **Fixed: Cursor agent rejecting turns as "prompt injection" / "gaslighting."**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Release 0.4.6 — includes the Cursor model catalog force-refresh fix (#65).

- Updates CHANGELOG.md
- Bumps package.json / package-lock.json to 0.4.6

Note: tag `v0.4.6` was already pushed and has triggered the release
workflow (repo rules block direct pushes to `main`, tags aren't
covered by that rule). **Merge this PR using "Merge commit" (not
squash)** so the `chore(release): 0.4.6` commit SHA on `main` matches
the SHA the `v0.4.6` tag already points to.