### PR TITLE
chore(release): 0.4.7-next.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.7-next.0] — 2026-07-17
+
+- **Fixed: subagents silently ran Cursor's server-side `fast` default (e.g.
+  `composer-2.5` in "fast" mode).** A subagent inherits its parent agent's
+  model but reached the provider with the model's `options.params` dropped, so
+  the `fast: "false"` opencode default was lost and Cursor's server-side
+  `fast: true` applied. Each model's default params are now threaded through the
+  provider options and re-applied as a lowest-precedence floor, so `fast` stays
+  off unless a variant or per-request param explicitly opts in. Set
+  `OPENCODE_CURSOR_DEBUG=1` to log the resolved model selection per turn (#71).
+
 ## [0.4.6] — 2026-07-08
 
 - **Fixed: newly released Cursor models didn't appear locally without a manual

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.6",
+  "version": "0.4.7-next.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.4.6",
+      "version": "0.4.7-next.0",
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.4.6",
+  "version": "0.4.7-next.0",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Pre-release cut for `0.4.7-next.0` → publishes to npm `next` dist-tag + GitHub pre-release on tag push.

## Included
- #71 — fix(provider): pin per-model default params on subagent turns (subagents no longer inherit Cursor's server-side `fast: true`).
- #63 — chore(deps): bump `@opencode-ai/plugin` 1.17.14 → 1.18.1 (lockfile; not changelogged per repo convention).

## Changes in this PR
- `package.json` / `package-lock.json`: `0.4.6` → `0.4.7-next.0`.
- `CHANGELOG.md`: new `## [0.4.7-next.0] — 2026-07-17` section for #71.

## After merge
Tag `v0.4.7-next.0` on the merged commit → `release.yml` publishes to npm (`next` tag) and creates a GitHub pre-release. Stable `latest` stays on 0.4.6.

Excluded: #69 (dev-deps, no artifact impact) and #70 (unreviewed feature) per the release scope.