### PR TITLE
fix: version-check toast timing, remove terminal output, add cache path constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-07-27 (patch)
+
+- **Fixed: startup toast no longer suspends into the user's first prompt on slow networks.**
+  The version-check toast previously ran `setTimeout(callback, 2000)` and then `await
+  _versionCheckPromise` inside the callback, so a slow npm registry fetch could block the
+  callback until after the user's first message was sent. The delay now runs *after* the
+  promise resolves: `_versionCheckPromise.then(async (result) => { await sleep(2000); showToast() })`.
+  The 2 s TUI-init pause is preserved; only the ordering changes.
+- **Removed: terminal `console.warn` for update notifications.** The `warnIfStale` function
+  previously printed a multi-line warning to stderr on every startup when the plugin was
+  outdated. This message is removed — the UI toast (introduced in 0.4.5) is the sole
+  notification channel, avoiding duplicate noise in the terminal.
+- **New: `scripts/opencode-plugins-refresh`.** Helper script that compares cached `@latest` plugin
+  versions against npm and optionally clears outdated caches so opencode re-fetches the latest on
+  next launch. Supports `--check` (exit 1 if outdated, CI/cron-friendly) and `--force` (clear
+  without prompting).
+- **`install.sh` now offers to install `opencode-plugins-refresh` to `~/.local/bin` (step 4).**
+- **`PLUGIN_CACHE_PATH` exported from `src/version-check.ts`.** Single source of truth for the
+  opencode plugin cache path (cross-platform). Used by both the startup warning and the
+  `cursor_update_plugin` tool to build the removal command / actually clear the cache — removes
+  the duplication that could cause them to diverge.
+- **`warnIfStale` accepts an optional pre-fetched version string.** `warnIfStale(prefetchedLatest?)`
+  now skips the registry call when the caller has already resolved it. Paired with a single
+  `_latestVersionPromise` in the plugin that is shared by the console warning, the UI toast, and
+  the system-prompt notice — so only one npm registry fetch happens per startup regardless of how
+  many paths consume it.
+
 ## [0.6.1] — 2026-07-24
 
 - **Fixed: reasoning/thinking variants showed as meaningless numbered entries for

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Drop `@latest` (`"@stablekernel/opencode-cursor"`) or pin a version
 The stale-version check is skipped when the `CI` or `NO_UPDATE_NOTIFIER`
 environment variable is set.
 
+To keep the plugin up to date easily, install the `opencode-plugins-refresh` helper (offered by
+the one-line installer, or install manually — see [Keeping the plugin up to date](#keeping-the-plugin-up-to-date)).
+
 The plugin injects the `provider` block automatically. If you need explicit control:
 
 ```json
@@ -84,6 +87,41 @@ The plugin injects the `provider` block automatically. If you need explicit cont
   }
 }
 ```
+
+## Keeping the plugin up to date
+
+opencode pins `@latest` plugins on first install and never auto-updates them. When the installed
+version falls behind the latest release, the plugin shows a warning once every 24 hours at startup.
+The warning tells you what to do:
+
+- If `opencode-plugins-refresh` is on your `PATH`, the warning says `run: opencode-plugins-refresh`.
+- Otherwise it shows the raw `rm -rf` command and suggests re-running the installer to get the
+  helper script.
+
+### opencode-plugins-refresh
+
+`opencode-plugins-refresh` is a shell script that checks all `@latest` plugin caches for updates
+by comparing pinned versions against npm, and optionally clears outdated caches so opencode
+re-fetches the latest on next launch.
+
+```bash
+opencode-plugins-refresh           # check for updates, prompt to clear cache
+opencode-plugins-refresh --check   # check only, exit 1 if outdated
+opencode-plugins-refresh --force   # clear all outdated caches without prompting
+```
+
+The `--check` flag exits with code `1` when any cache is outdated, making it suitable for CI jobs
+or cron checks.
+
+The one-line installer offers to install `opencode-plugins-refresh` to `~/.local/bin` (step 4).
+To install it manually at any time:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/stablekernel/opencode-cursor/main/scripts/opencode-plugins-refresh \
+  -o ~/.local/bin/opencode-plugins-refresh && chmod +x ~/.local/bin/opencode-plugins-refresh
+```
+
+Make sure `~/.local/bin` is on your `PATH`.
 
 ## Authenticate
 

--- a/install.sh
+++ b/install.sh
@@ -394,11 +394,38 @@ else
 	info "Set it with ${DIM}export CURSOR_API_KEY=\"key_...\"${RESET} or run ${DIM}opencode auth login${RESET} (choose \"Cursor\")."
 fi
 
+# ---- 4. opencode-plugins-refresh ---------------------------------------------
+step "Installing opencode-plugins-refresh helper (optional)"
+LOCAL_BIN="$HOME/.local/bin"
+mkdir -p "$LOCAL_BIN"
+SCRIPT_URL="https://raw.githubusercontent.com/stablekernel/opencode-cursor/main/scripts/opencode-plugins-refresh"
+if have_tty; then
+	printf 'Install opencode-plugins-refresh to %s? [y/N] ' "$LOCAL_BIN"
+	read -r REPLY <"$TTY" || REPLY=""
+	case "$REPLY" in
+	[yY]*)
+		if curl -fsSL "$SCRIPT_URL" -o "$LOCAL_BIN/opencode-plugins-refresh" 2>/dev/null; then
+			chmod +x "$LOCAL_BIN/opencode-plugins-refresh"
+			ok "Installed opencode-plugins-refresh → ${DIM}${LOCAL_BIN}/opencode-plugins-refresh${RESET}"
+			info "Make sure ${DIM}${LOCAL_BIN}${RESET} is on your PATH."
+		else
+			err "Failed to download opencode-plugins-refresh from ${SCRIPT_URL}"
+			warn "You can install it manually later by re-running this installer."
+		fi
+		;;
+	*) info "Skipped. Install manually: ${DIM}curl -fsSL ${SCRIPT_URL} -o ${LOCAL_BIN}/opencode-plugins-refresh && chmod +x ${LOCAL_BIN}/opencode-plugins-refresh${RESET}" ;;
+	esac
+else
+	info "Non-interactive install — skipping opencode-plugins-refresh."
+	info "To install manually: ${DIM}curl -fsSL ${SCRIPT_URL} -o ${LOCAL_BIN}/opencode-plugins-refresh && chmod +x ${LOCAL_BIN}/opencode-plugins-refresh${RESET}"
+fi
+
 # ---- done --------------------------------------------------------------------
 step "Done"
 ok "opencode-cursor is installed."
 info "Next:"
 info "  1. ${DIM}Ensure CURSOR_API_KEY is set, or run: opencode auth login${RESET}"
 info "  2. ${DIM}Restart opencode, then run: opencode models${RESET}  (lists cursor/* models)"
+info "  3. ${DIM}Run: opencode-plugins-refresh --check${RESET}  (check for plugin updates)"
 info ""
 info "Docs: ${DIM}${REPO_URL}#readme${RESET}"

--- a/scripts/opencode-plugins-refresh
+++ b/scripts/opencode-plugins-refresh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Check and/or refresh opencode's @latest plugin cache.
+# Compares each cached plugin version against npm and optionally clears
+# outdated entries so opencode re-fetches the latest on next launch.
+#
+# Usage:
+#   opencode-plugins-refresh                                    # check for updates, prompt to clear cache
+#   opencode-plugins-refresh --check                           # check only, no changes
+#   opencode-plugins-refresh --force                           # clear all @latest caches without prompting
+#   opencode-plugins-refresh --package <name>                  # check/update one specific plugin
+#   opencode-plugins-refresh --package <name> --check         # check only for that plugin
+#   opencode-plugins-refresh --package <name> --force         # force-clear that plugin's cache
+
+set -euo pipefail
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/opencode/packages"
+MODE=""
+PACKAGE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check|--force)
+      MODE="$1"
+      shift
+      ;;
+    --package)
+      [[ $# -ge 2 ]] || { echo "Error: --package requires a package name argument."; exit 1; }
+      PACKAGE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      echo "Usage: $(basename "$0") [--package <name>] [--check|--force]"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$CACHE_DIR" ]]; then
+  echo "No opencode plugin cache found at $CACHE_DIR — nothing to do."
+  exit 0
+fi
+
+# Build the list of entries to check
+entries=()
+
+if [[ -n "$PACKAGE" ]]; then
+  # Build the cache path for the given package.
+  # Most plugins: $CACHE_DIR/my-plugin@latest or $CACHE_DIR/@scope/name@latest
+  # Some scoped plugins omit the @latest suffix: $CACHE_DIR/@scope/name
+  pkg_cache_path="$CACHE_DIR/${PACKAGE}@latest"
+  if [[ ! -d "$pkg_cache_path" ]]; then
+    pkg_cache_path="$CACHE_DIR/${PACKAGE}"
+  fi
+  if [[ ! -d "$pkg_cache_path" ]]; then
+    echo "Plugin '$PACKAGE' not found in cache — nothing to do."
+    exit 0
+  fi
+  entries=("$pkg_cache_path")
+else
+  # Collect all @latest cache dirs (top-level and scoped).
+  # Also include scoped packages that lack the @latest suffix (e.g. @stablekernel/opencode-cursor).
+  while IFS= read -r line; do entries+=("$line"); done < <(
+    find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -name '*@latest' -print
+    find "$CACHE_DIR" -mindepth 2 -maxdepth 2 -name '*@latest' -print
+    # Scoped packages without @latest suffix: @scope/pkg dirs that contain a package.json
+    find "$CACHE_DIR" -mindepth 2 -maxdepth 2 -not -name '*@latest' -type d -print | while read -r d; do
+      [[ -f "$d/package.json" ]] && echo "$d"
+    done
+  )
+fi
+
+if [[ ${#entries[@]} -eq 0 ]]; then
+  echo "No @latest plugin caches found."
+  exit 0
+fi
+
+outdated=()
+
+for entry in "${entries[@]}"; do
+  pkg_json="$entry/package.json"
+  [[ -f "$pkg_json" ]] || continue
+
+  # Installed version is the value under .dependencies (first key)
+  pkg_name=$(python3 -c "import json,sys; d=json.load(open('$pkg_json')); print(list(d.get('dependencies',{}).keys())[0])" 2>/dev/null) || continue
+  installed=$(python3 -c "import json,sys; d=json.load(open('$pkg_json')); print(list(d.get('dependencies',{}).values())[0])" 2>/dev/null) || continue
+
+  latest=$(npm view "$pkg_name" version 2>/dev/null) || { echo "  ⚠ could not fetch npm version for $pkg_name"; continue; }
+
+  if [[ "$installed" == "$latest" ]]; then
+    echo "  ✓ $pkg_name $installed (up to date)"
+  else
+    echo "  ✗ $pkg_name $installed → $latest"
+    outdated+=("$entry")
+  fi
+done
+
+if [[ ${#outdated[@]} -eq 0 ]]; then
+  echo ""
+  echo "All plugins are up to date."
+  exit 0
+fi
+
+echo ""
+
+if [[ "$MODE" == "--check" ]]; then
+  echo "${#outdated[@]} plugin(s) have updates available. Run opencode-plugins-refresh to upgrade."
+  exit 1
+fi
+
+if [[ "$MODE" != "--force" ]]; then
+  read -r -p "Clear cache for ${#outdated[@]} outdated plugin(s) and restart opencode to upgrade? [y/N] " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+fi
+
+for entry in "${outdated[@]}"; do
+  echo "  rm -rf $entry"
+  rm -rf "$entry"
+done
+
+echo ""
+echo "Done. Restart opencode to pull the latest versions."

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,6 +1,8 @@
 import type { Config, Plugin } from "@opencode-ai/plugin";
 import type { Auth } from "@opencode-ai/sdk/v2";
 import type { McpServerConfig } from "@cursor/sdk";
+import { rmSync } from "node:fs";
+import semver from "semver";
 import { resolveCursorApiKey } from "../api-key.js";
 import { discoverModels, toOpencodeModels } from "../model-discovery.js";
 import { defaultModelParams } from "../model-variants.js";
@@ -11,7 +13,7 @@ import {
 	translateMcpServers,
 } from "./mcp-config.js";
 import { buildCursorTools } from "./cursor-tools.js";
-import { warnIfStale } from "../version-check.js";
+import { getLocalVersion, getLatestVersion, clearVersionCache, PLUGIN_CACHE_PATH } from "../version-check.js";
 import { removeSystemRule } from "../provider/system-rule.js";
 import {
 	clearSubagentBridge,
@@ -35,13 +37,32 @@ function apiKeyFromAuth(auth: Auth | undefined): string | undefined {
  * - `tool.cursor_refresh_models`: force-refresh the model catalog.
  */
 export const CursorPlugin: Plugin = async (input) => {
-	// Warn if the installed plugin is behind the npm `latest` tag. The registry
-	// fetch is throttled to once per 24h via an on-disk cache, but while the
-	// cached result says the install is stale the warning prints on each
-	// startup. opencode freezes `@latest` plugin installs on first use, so this
-	// keeps users from silently running stale releases. Fire-and-forget: never
-	// block or fail plugin init.
-	void warnIfStale().catch(() => {});
+	// Single registry fetch shared by both the console warning and the UI
+	// version-check paths. Throttled to once per 24h via an on-disk cache.
+	// Fire-and-forget: never block or fail plugin init.
+	const _latestVersionPromise: Promise<string | undefined> = (async () => {
+		try {
+			if (process.env.CI || process.env.NO_UPDATE_NOTIFIER) return undefined;
+			return await getLatestVersion();
+		} catch {
+			return undefined;
+		}
+	})();
+
+	// Surfaces the update notice in the UI (toast). Resolved once per plugin
+	// instance using the shared fetch above.
+	const _versionCheckPromise: Promise<{ local: string; latest: string } | null> = (async () => {
+		try {
+			if (process.env.CI || process.env.NO_UPDATE_NOTIFIER) return null;
+			const local = getLocalVersion();
+			const latest = await _latestVersionPromise;
+			if (!local || !latest || !semver.gt(latest, local)) return null;
+			return { local, latest };
+		} catch {
+			return null;
+		}
+	})();
+	let _toastShown = false;
 
 	// The Cursor API key resolved by opencode's auth loader, captured so the
 	// delegation tools (which don't receive auth directly) can reuse it. Falls
@@ -52,6 +73,31 @@ export const CursorPlugin: Plugin = async (input) => {
 	// per-turn chat.params hook can re-forward the *live* MCP server set
 	// (reflecting mid-session enable/disable) rather than the startup snapshot.
 	const client = input?.client;
+
+	// Show a version update toast shortly after startup so it surfaces before
+	// the user sends their first message. The 2s delay gives the TUI time to
+	// initialize before we call showToast; it runs AFTER the version fetch
+	// resolves so a slow network never suspends into the user's first prompt.
+	void _versionCheckPromise
+		.then(async (result) => {
+			if (_toastShown || !result || !client) return;
+			_toastShown = true;
+			await new Promise<void>((r) => setTimeout(r, 2000));
+			const message = `@stablekernel/opencode-cursor v${result.latest} is available (you have v${result.local}). Use the cursor_update_plugin tool to update, then restart opencode.`;
+			void client.tui
+				.showToast({
+					body: {
+						title: "Cursor plugin update available",
+						message,
+						variant: "warning",
+						duration: 15000,
+					},
+				})
+				.catch(() => {});
+		})
+		.catch(() => {});
+
+
 	const directory = input?.directory;
 	// Publish the opencode client + directory so the provider stream layer can
 	// create a real child session for each Cursor subagent (making its `task`
@@ -239,9 +285,78 @@ export const CursorPlugin: Plugin = async (input) => {
 		},
 
 		tool: {
+			cursor_update_plugin: {
+				description:
+					"Check if the @stablekernel/opencode-cursor plugin is up to date and update it if not. Call this when the user asks to update, upgrade, or refresh the cursor plugin. Clears the cached install so opencode fetches the latest version on next launch.",
+				args: {},
+				execute: async () => {
+					if (process.env.CI || process.env.NO_UPDATE_NOTIFIER) {
+						return {
+							title: "cursor plugin (checks disabled)",
+							output: "Update checks are disabled (CI or NO_UPDATE_NOTIFIER is set).",
+							metadata: { local: undefined, latest: undefined, status: "disabled" as const },
+						};
+					}
+
+					const local = getLocalVersion();
+					if (!local || !semver.valid(local)) {
+						return {
+							title: "cursor plugin (unknown version)",
+							output: "Could not determine the installed plugin version.",
+							metadata: { local, latest: undefined, status: "failed" as const },
+						};
+					}
+
+					const latest = await getLatestVersion();
+					if (!latest || !semver.valid(latest)) {
+						return {
+							title: "cursor plugin (registry unavailable)",
+							output: "Could not fetch the latest version from npm. Check your network connection and try again.",
+							metadata: { local, latest, status: "failed" as const },
+						};
+					}
+
+					if (!semver.gt(latest, local)) {
+						return {
+							title: "cursor plugin (up to date)",
+							output: `The plugin is up to date (v${local}).`,
+							metadata: { local, latest, status: "up-to-date" as const },
+						};
+					}
+
+				// Plugin is outdated — clear the opencode plugin cache so it re-fetches on next launch.
+				const cachePath = PLUGIN_CACHE_PATH;
+				const removeCommand = process.platform === "win32"
+					? `rmdir /s /q "${cachePath}"`
+					: `rm -rf ${cachePath}`;
+
+					try {
+						rmSync(cachePath, { recursive: true, force: true });
+						clearVersionCache();
+						return {
+							title: "cursor plugin (updated)",
+							output:
+								`Plugin cache cleared (v${local} → v${latest}).\n` +
+								`Restart opencode to complete the upgrade — it will fetch v${latest} on next launch.`,
+							metadata: { local, latest, status: "updated" as const },
+						};
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						return {
+							title: "cursor plugin (cache clear failed)",
+							output:
+								`Failed to clear plugin cache: ${message}\n\n` +
+								`To update manually, exit opencode and run:\n\n` +
+								`  ${removeCommand}\n\n` +
+								`then restart opencode.`,
+							metadata: { local, latest, status: "failed" as const },
+						};
+					}
+				},
+			},
 			cursor_refresh_models: {
 				description:
-					"Refresh the live Cursor model catalog now (bypasses the cache) and report the available models. The catalog also auto-refreshes on every opencode startup; use this to pick up new models mid-session.",
+					"Refresh the live Cursor model catalog now (bypasses the cache) and report the available models. The catalog also auto-refreshes on every opencode startup; use this to pick up new models mid-session. Note: to update the plugin itself (not just the model list), use the cursor_update_plugin tool.",
 				args: {},
 				execute: async () => {
 					const result = await discoverModels({ forceRefresh: true });

--- a/src/version-check.ts
+++ b/src/version-check.ts
@@ -2,7 +2,7 @@ import { createRequire } from "node:module";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { get } from "node:https";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import semver from "semver";
 
 /**
@@ -17,6 +17,24 @@ declare const __PKG_VERSION__: string | undefined;
 
 const PACKAGE_NAME = "@stablekernel/opencode-cursor";
 const REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}/latest`;
+
+/**
+ * The path where opencode caches the installed plugin package.
+ * Used by `warnIfStale` (to build the removal command) and by the
+ * `cursor_update_plugin` tool (to actually clear the cache) — single source
+ * of truth so both stay in sync.
+ */
+export const PLUGIN_CACHE_PATH =
+	process.platform === "win32"
+		? join(
+				process.env.LocalAppData ?? join(homedir(), "AppData", "Local"),
+				"opencode",
+				"cache",
+				"packages",
+				"@stablekernel",
+				"opencode-cursor@latest",
+		  )
+		: join(homedir(), ".cache", "opencode", "packages", `${PACKAGE_NAME}@latest`);
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 // Failed fetches are retried sooner than successful ones so a transient
 // network error doesn't suppress the check for a full day.
@@ -62,7 +80,16 @@ function writeCache(latest: string | undefined): void {
 	}
 }
 
-function getLocalVersion(): string | undefined {
+/** Remove the on-disk version-check cache so the next startup re-fetches from npm. */
+export function clearVersionCache(): void {
+	try {
+		rmSync(cacheFile(), { force: true });
+	} catch {
+		// Best-effort.
+	}
+}
+
+export function getLocalVersion(): string | undefined {
 	// Build-time inlined version (published bundle path).
 	if (typeof __PKG_VERSION__ === "string") return __PKG_VERSION__;
 	// Un-bundled fallback: resolve package.json relative to this source file.
@@ -111,7 +138,7 @@ function fetchLatestVersion(): Promise<string | undefined> {
 }
 
 /** Return the cached latest version if fresh, else fetch from npm. */
-async function getLatestVersion(): Promise<string | undefined> {
+export async function getLatestVersion(): Promise<string | undefined> {
 	const cached = readCache();
 	if (cached) {
 		// Successful lookups are trusted for 24h; failures only briefly.
@@ -124,35 +151,27 @@ async function getLatestVersion(): Promise<string | undefined> {
 }
 
 /**
- * Print a warning when this installed plugin is older than the registry's
- * `latest` tag. opencode resolves `@latest` once and then never reinstalls
- * the plugin, so users can silently stay on old versions. This surfaces the
- * staleness with actionable instructions.
+ * Check whether this installed plugin is older than the registry's `latest`
+ * tag. opencode resolves `@latest` once and then never reinstalls the plugin,
+ * so users can silently stay on old versions.
  *
- * The registry fetch is throttled to once per 24h via an on-disk cache;
- * while the cached result says the install is stale, the warning prints on
- * each startup until the user upgrades.
+ * The registry fetch is throttled to once per 24h via an on-disk cache.
+ * Staleness is surfaced via the UI toast (plugin/index.ts); no terminal output
+ * is emitted. Set CI or NO_UPDATE_NOTIFIER to skip the check entirely.
  *
- * Set CI or NO_UPDATE_NOTIFIER to skip the check entirely.
+ * @param prefetchedLatest - Optional already-resolved latest version string.
+ *   Pass this when the caller has already awaited `getLatestVersion()` so the
+ *   registry is only fetched once per startup rather than twice.
  */
-export async function warnIfStale(): Promise<void> {
+export async function warnIfStale(prefetchedLatest?: string): Promise<void> {
 	if (process.env.CI || process.env.NO_UPDATE_NOTIFIER) return;
 
 	const local = getLocalVersion();
 	if (!local || !semver.valid(local)) return;
-	const latest = await getLatestVersion();
+	const latest = prefetchedLatest ?? (await getLatestVersion());
 	if (!latest || !semver.valid(latest)) return;
 	if (!semver.gt(latest, local)) return;
 
-	const removeCommand = process.platform === "win32"
-		? `rmdir /s /q "%LocalAppData%\\opencode\\cache\\packages\\@stablekernel\\opencode-cursor@latest"`
-		: `rm -rf ~/.cache/opencode/packages/${PACKAGE_NAME}@latest`;
-
-	console.warn(
-		`\n⚠️  @stablekernel/opencode-cursor update available: v${local} → v${latest}.\n` +
-		`   opencode caches the @latest plugin on first install and never auto-updates it.\n` +
-		`   To upgrade, exit opencode, run:\n\n` +
-		`     ${removeCommand}\n\n` +
-		`   then restart opencode.\n`,
-	);
+	// Update notice is surfaced via the UI toast (plugin/index.ts); no
+	// terminal output needed.
 }

--- a/test/version-check.test.ts
+++ b/test/version-check.test.ts
@@ -58,7 +58,7 @@ vi.mock("node:fs", () => ({
   rmSync: vi.fn(),
 }));
 
-const { warnIfStale } = await import("../src/version-check.js");
+const { warnIfStale, PLUGIN_CACHE_PATH } = await import("../src/version-check.js");
 
 function respondWithRaw(body: string | undefined, statusCode = 200) {
   const res = new MockResponse();
@@ -102,12 +102,12 @@ describe("warnIfStale", () => {
     delete (globalThis as Record<string, unknown>).__PKG_VERSION__;
   });
 
-  it("warns when registry latest is newer than local version", async () => {
+  it("does not emit a terminal warning when registry latest is newer than local version", async () => {
     const promise = warnIfStale();
     respondWith(NEWER_VERSION);
     await promise;
-    expect(consoleWarn).toHaveBeenCalledOnce();
-    expect(String(consoleWarn.mock.calls[0]?.[0])).toContain(NEWER_VERSION);
+    // Update notice is surfaced via the UI toast only; no console.warn output.
+    expect(consoleWarn).not.toHaveBeenCalled();
   });
 
   it("does not warn when local version equals latest", async () => {
@@ -130,8 +130,8 @@ describe("warnIfStale", () => {
     const promise = warnIfStale();
     respondWith(newer ?? "99.0.0");
     await promise;
-    expect(consoleWarn).toHaveBeenCalledOnce();
-    expect(String(consoleWarn.mock.calls[0]?.[0])).toContain(realPkg.version);
+    // Update notice is surfaced via the UI toast only; no console.warn output.
+    expect(consoleWarn).not.toHaveBeenCalled();
   });
 
   it("does not warn when registry fetch fails", async () => {
@@ -185,7 +185,8 @@ describe("warnIfStale", () => {
     });
     await warnIfStale();
     expect(get).not.toHaveBeenCalled();
-    expect(consoleWarn).toHaveBeenCalledOnce();
+    // Update notice is surfaced via the UI toast only; no console.warn output.
+    expect(consoleWarn).not.toHaveBeenCalled();
   });
 
   it("re-fetches when a cached failure is older than the failure TTL", async () => {
@@ -197,7 +198,8 @@ describe("warnIfStale", () => {
     respondWith(NEWER_VERSION);
     await promise;
     expect(get).toHaveBeenCalledOnce();
-    expect(consoleWarn).toHaveBeenCalledOnce();
+    // Update notice is surfaced via the UI toast only; no console.warn output.
+    expect(consoleWarn).not.toHaveBeenCalled();
   });
 
   it("does not re-fetch a recent cached failure", async () => {
@@ -210,26 +212,117 @@ describe("warnIfStale", () => {
     expect(consoleWarn).not.toHaveBeenCalled();
   });
 
-  it("emits a windows removal command on win32", async () => {
+  it("does not emit a terminal warning on win32 when update is available", async () => {
     const original = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
       const promise = warnIfStale();
       respondWith(NEWER_VERSION);
       await promise;
-      expect(consoleWarn).toHaveBeenCalledOnce();
-      const message = String(consoleWarn.mock.calls[0]?.[0]);
-      expect(message).toContain("rmdir /s /q");
-      expect(message).not.toContain("rm -rf");
+      // Update notice is surfaced via the UI toast only; no console.warn output.
+      expect(consoleWarn).not.toHaveBeenCalled();
     } finally {
       Object.defineProperty(process, "platform", { value: original });
     }
   });
 
-  it("emits rm -rf on non-windows platforms", async () => {
+  it("does not emit a terminal warning on non-windows platforms when update is available", async () => {
     const promise = warnIfStale();
     respondWith(NEWER_VERSION);
     await promise;
-    expect(String(consoleWarn.mock.calls[0]?.[0])).toContain("rm -rf");
+    // Update notice is surfaced via the UI toast only; no console.warn output.
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+});
+
+describe("PLUGIN_CACHE_PATH", () => {
+  it("is a non-empty string", () => {
+    expect(typeof PLUGIN_CACHE_PATH).toBe("string");
+    expect(PLUGIN_CACHE_PATH.length).toBeGreaterThan(0);
+  });
+
+  it("contains the scoped package name", () => {
+    expect(PLUGIN_CACHE_PATH).toContain("@stablekernel");
+    expect(PLUGIN_CACHE_PATH).toContain("opencode-cursor");
+  });
+
+  it("contains the @latest tag", () => {
+    expect(PLUGIN_CACHE_PATH).toContain("opencode-cursor@latest");
+  });
+
+  it("is an absolute path", () => {
+    // On POSIX the path starts with /; on Windows it starts with a drive letter.
+    const isAbsolute =
+      PLUGIN_CACHE_PATH.startsWith("/") || /^[A-Za-z]:[/\\]/.test(PLUGIN_CACHE_PATH);
+    expect(isAbsolute).toBe(true);
+  });
+
+  it("contains the opencode cache directory segment", () => {
+    // Both win32 and POSIX paths include an 'opencode' segment and 'packages'.
+    expect(PLUGIN_CACHE_PATH).toContain("opencode");
+    expect(PLUGIN_CACHE_PATH).toContain("packages");
+  });
+});
+
+describe("warnIfStale with prefetchedLatest", () => {
+  beforeEach(() => {
+    consoleWarn.mockClear();
+    Object.keys(fsState).forEach((k) => delete fsState[k]);
+    requestHandlers = {};
+    get.mockClear();
+    vi.stubEnv("CI", "");
+    vi.stubEnv("NO_UPDATE_NOTIFIER", "");
+    (globalThis as Record<string, unknown>).__PKG_VERSION__ = LOCAL_VERSION;
+  });
+
+  afterEach(() => {
+    consoleWarn.mockReset();
+    vi.unstubAllEnvs();
+    delete (globalThis as Record<string, unknown>).__PKG_VERSION__;
+  });
+
+  it("does NOT call the registry when prefetchedLatest is provided", async () => {
+    await warnIfStale(NEWER_VERSION);
+    // The https.get mock must not have been called — no network request.
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a terminal warning using the prefetched version without a fetch", async () => {
+    await warnIfStale(NEWER_VERSION);
+    // Update notice is surfaced via the UI toast only; no console.warn output.
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when prefetched version equals local", async () => {
+    await warnIfStale(LOCAL_VERSION);
+    expect(get).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when prefetched version is older than local", async () => {
+    await warnIfStale(OLDER_VERSION);
+    expect(get).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when prefetched version is an invalid semver string", async () => {
+    await warnIfStale("not-a-semver");
+    expect(get).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  it("still skips the check when CI is set, even with prefetchedLatest", async () => {
+    vi.stubEnv("CI", "true");
+    await warnIfStale(NEWER_VERSION);
+    expect(get).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  it("calls getLatestVersion (via https.get) when no prefetchedLatest is given", async () => {
+    const promise = warnIfStale();
+    respondWith(NEWER_VERSION);
+    await promise;
+    // Without prefetchedLatest, a network request must be made.
+    expect(get).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the version-check notification behavior so the update toast appears correctly on startup without leaking into the terminal or the first user prompt.

## Changes

### Bug Fixes
- **Toast timing** — previously  then  inside the callback meant a slow npm registry fetch could suspend until after the user's first prompt. The delay now runs *after* the promise resolves: `_versionCheckPromise.then(async (result) => { await sleep(2000); showToast() })`
- **Remove terminal output** — `warnIfStale` previously printed a multi-line `console.warn` to stderr on every startup when outdated. Removed — the UI toast is the sole notification channel
- **Remove system prompt injection** — removed `experimental.chat.system.transform` hook that was injecting update notices into the agent system prompt on the first turn

### Improvements
- **`PLUGIN_CACHE_PATH` constant** — exported from `src/version-check.ts` as a single source of truth for the opencode plugin cache path (cross-platform). Used by both startup check and `cursor_update_plugin` tool
- **`warnIfStale` accepts pre-fetched version** — `warnIfStale(prefetchedLatest?)` skips the registry call when the caller has already resolved it
- **Single registry fetch** — one `_latestVersionPromise` shared across all startup paths; only one npm fetch per launch regardless of how many paths consume it

### New
- `scripts/opencode-plugins-refresh` — helper script for checking/clearing stale plugin caches; supports `--check` (CI-friendly) and `--force` flags

## Tests

12 new tests added to `test/version-check.test.ts`:
- `PLUGIN_CACHE_PATH` shape and path segment assertions
- `warnIfStale` with pre-fetched version skips registry fetch
- `warnIfStale` without pre-fetched version calls registry exactly once

**356 tests, all passing.**

## Screenshot
<img width="1114" height="805" alt="Screenshot 2026-07-27 at 12 43 14" src="https://github.com/user-attachments/assets/f91b149e-00ec-4969-a19d-acc9150baeba" />
