### PR TITLE
fix(provider): honor the host's tool set so compaction can summarize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **Fixed: auto-compaction (and manual `/compact`) failed with `Tool call not
+  allowed while generating summary` whenever the Cursor agent used a tool while
+  summarizing.** opencode declares zero tools on a compaction/summary turn, but
+  the Cursor agent runs its own tools regardless; the provider forwarded that
+  activity as provider-executed `tool-call` parts, which opencode's summary
+  guard rejects. The provider now routes no-tools turns through the existing
+  `"reasoning"` tool-display path, so Cursor's tool activity surfaces as
+  reasoning text instead of crossing the tool-execution boundary. Manual
+  `/compact` was affected all along; **auto**-compaction became reachable only
+  in 0.7.1-next.0, because #89 published real per-model context windows —
+  pre-0.7.1 opencode saw `limit.context: 0` for every Cursor model, and a zero
+  context limit structurally disables the auto-compaction trigger.
+
 ## [0.7.1-next.0] — 2026-08-03 (pre-release)
 
 Pre-release of the skills bridge (#90) and per-model context limits + pricing

--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ open a PR.
 - **`"reasoning"`** — compact inline lines (`[tool] write {"path":…}`). Works on any host; use
   this on older opencode versions.
 
+Turns where the host declares no tools at all — compaction/summary and title generation — always
+use `"reasoning"` regardless of this setting. opencode rejects tool parts on a summary turn, so
+Cursor's tool activity is folded into reasoning text there instead.
+
 To force the fallback:
 
 ```json

--- a/src/provider/language-model.ts
+++ b/src/provider/language-model.ts
@@ -34,6 +34,7 @@ import {
 import {
 	cursorEventsToContent,
 	cursorEventsToStream,
+	effectiveToolDisplay,
 	type ToolDisplay,
 } from "./stream-map.js";
 import { resolveControls } from "./controls.js";
@@ -549,9 +550,11 @@ export class CursorLanguageModel implements LanguageModelV3 {
 				? (po["sessionID"] as string)
 				: undefined;
 		return {
-			stream: cursorEventsToStream(this.agentRun(options), this.config.toolDisplay, {
-				sessionID,
-			}),
+			stream: cursorEventsToStream(
+				this.agentRun(options),
+				effectiveToolDisplay(this.config.toolDisplay, options.tools),
+				{ sessionID },
+			),
 		};
 	}
 
@@ -563,7 +566,7 @@ export class CursorLanguageModel implements LanguageModelV3 {
 	}> {
 		const result = await cursorEventsToContent(
 			this.agentRun(options),
-			this.config.toolDisplay,
+			effectiveToolDisplay(this.config.toolDisplay, options.tools),
 		);
 		return { ...result, warnings: [] };
 	}

--- a/src/provider/stream-map.ts
+++ b/src/provider/stream-map.ts
@@ -1,4 +1,5 @@
 import type {
+	LanguageModelV3CallOptions,
 	LanguageModelV3Content,
 	LanguageModelV3FinishReason,
 	LanguageModelV3StreamPart,
@@ -54,6 +55,24 @@ function injectSubagentSessionId(
  *    treated as dynamic.
  */
 export type ToolDisplay = "reasoning" | "blocks";
+
+/**
+ * A host that declared no tools cannot accept tool parts — opencode's summary
+ * guard throws on them (`Tool call not allowed while generating summary`).
+ * Cursor's agent runs its own tools regardless, so fold that activity into
+ * reasoning text for those turns. Returns the configured mode otherwise.
+ */
+export function effectiveToolDisplay(
+	configured: ToolDisplay | undefined,
+	tools: LanguageModelV3CallOptions["tools"],
+): ToolDisplay {
+	// `Array.isArray` rather than a null check: opencode passes tools as a
+	// Record at its own layer and the ai-sdk converts it to an array (an empty
+	// Record short-circuits to `undefined`), so a raw record never reaches us
+	// today — but this way the guard holds even if that conversion changes.
+	if (!Array.isArray(tools) || tools.length === 0) return "reasoning";
+	return configured ?? "blocks";
+}
 
 const FINISH_STOP: LanguageModelV3FinishReason = {
 	unified: "stop",

--- a/test/language-model.test.ts
+++ b/test/language-model.test.ts
@@ -457,3 +457,122 @@ describe("CursorLanguageModel doStream — resume-aware retry", () => {
 		expect((error.cause as Error)?.message).toContain("error");
 	});
 });
+
+// Regression for "Tool call not allowed while generating summary" on turns
+// where opencode declares no tools (compaction/summary, title generation).
+// The Cursor agent runs its own tools regardless; the provider must fold that
+// activity into reasoning text rather than emitting provider-executed
+// tool-call parts the host cannot accept.
+describe("CursorLanguageModel — no-tools turns fold tool activity into reasoning", () => {
+	const TOOL_TYPES = [
+		"tool-input-start",
+		"tool-input-delta",
+		"tool-input-end",
+		"tool-call",
+		"tool-result",
+	] as const;
+
+	// A Cursor tool-call for an MCP tool (the shape that produced the reported
+	// `cursor_context-mode_ctx_search` part).
+	const mcpToolCallUpdate = {
+		type: "tool-call-started",
+		callId: "c1",
+		toolCall: { type: "mcp", args: { toolName: "context-mode_ctx_search", providerIdentifier: "context-mode" } },
+	};
+	const mcpToolResultUpdate = {
+		type: "tool-call-completed",
+		callId: "c1",
+		toolCall: { type: "mcp", result: { content: [{ type: "text", text: "ok" }] } },
+	};
+
+	it("doStream: a no-tools turn emits no tool parts", async () => {
+		const model = makeModel();
+		create.mockResolvedValueOnce(
+			fakeAgent({
+				agentId: "a1",
+				updates: [mcpToolCallUpdate, mcpToolResultUpdate, { type: "text-delta", text: "summary" }],
+			}),
+		);
+
+		const parts = await collectStream(
+			streamCall(model, {
+				prompt: [user("summarize")],
+				// tools intentionally omitted — mirrors opencode's compaction turn
+				providerOptions: { cursor: { sessionID: "s1" } },
+			} as never),
+		);
+
+		for (const t of TOOL_TYPES) {
+			expect(eventTypes(parts)).not.toContain(t);
+		}
+
+		// Absence alone would also hold if the stream emitted nothing, so assert
+		// the activity was FOLDED INTO reasoning rather than dropped.
+		const reasoning = parts
+			.filter(
+				(p): p is Extract<LanguageModelV3StreamPart, { type: "reasoning-delta" }> =>
+					p.type === "reasoning-delta",
+			)
+			.map((p) => p.delta)
+			.join("");
+		expect(reasoning).toContain("context-mode_ctx_search");
+		// The summary text itself still reaches the host.
+		const text = parts
+			.filter(
+				(p): p is Extract<LanguageModelV3StreamPart, { type: "text-delta" }> =>
+					p.type === "text-delta",
+			)
+			.map((p) => p.delta)
+			.join("");
+		expect(text).toBe("summary");
+	});
+
+	it("doStream: a turn WITH tools still emits tool-call parts", async () => {
+		const model = makeModel();
+		create.mockResolvedValueOnce(
+			fakeAgent({
+				agentId: "a1",
+				updates: [mcpToolCallUpdate, mcpToolResultUpdate, { type: "text-delta", text: "done" }],
+			}),
+		);
+
+		const parts = await collectStream(
+			streamCall(model, {
+				prompt: [sys("S"), user("hi")],
+				tools: [{ type: "function", name: "read", inputSchema: {} }],
+				providerOptions: { cursor: { sessionID: "s1" } },
+			} as never),
+		);
+
+		// Normal tool blocks are preserved — the suppression is no-tools-only.
+		expect(eventTypes(parts)).toContain("tool-call");
+	});
+
+	it("doGenerate: a no-tools turn carries no tool-call in content", async () => {
+		const model = makeModel();
+		create.mockResolvedValueOnce(
+			fakeAgent({
+				agentId: "a1",
+				updates: [mcpToolCallUpdate, mcpToolResultUpdate, { type: "text-delta", text: "summary" }],
+			}),
+		);
+
+		const result = await model.doGenerate({
+			prompt: [user("summarize")],
+			providerOptions: { cursor: { sessionID: "s1" } },
+		} as never);
+
+		const toolContent = result.content.filter((c) => c.type === "tool-call");
+		expect(toolContent).toHaveLength(0);
+
+		// Folded into reasoning, not dropped.
+		const reasoning = result.content
+			.filter(
+				(c): c is Extract<typeof c, { type: "reasoning" }> =>
+					c.type === "reasoning",
+			)
+			.map((c) => c.text)
+			.join("");
+		expect(reasoning).toContain("context-mode_ctx_search");
+	});
+});

--- a/test/stream-map.test.ts
+++ b/test/stream-map.test.ts
@@ -4,6 +4,7 @@ import type { CursorEvent } from "../src/provider/agent-events.js";
 import {
 	cursorEventsToContent,
 	cursorEventsToStream,
+	effectiveToolDisplay,
 	mapUsage,
 } from "../src/provider/stream-map.js";
 import {
@@ -1694,5 +1695,27 @@ describe("subagent child-session linking (blocks)", () => {
 		);
 		const result = toolResults(parts)[0]!;
 		expect(foldedMetadata(result)["sessionId"]).toBeUndefined();
+	});
+});
+
+describe("effectiveToolDisplay", () => {
+	it("returns \"reasoning\" when tools are undefined", () => {
+		expect(effectiveToolDisplay("blocks", undefined)).toBe("reasoning");
+	});
+
+	it("returns \"reasoning\" when tools are an empty array", () => {
+		expect(effectiveToolDisplay("blocks", [])).toBe("reasoning");
+	});
+
+	it("returns the configured mode when tools are present", () => {
+		expect(effectiveToolDisplay("blocks", [{ type: "function", name: "read" } as never])).toBe(
+			"blocks",
+		);
+	});
+
+	it("defaults to \"blocks\" when configured is undefined and tools are present", () => {
+		expect(
+			effectiveToolDisplay(undefined, [{ type: "function", name: "read" } as never]),
+		).toBe("blocks");
 	});
 });


### PR DESCRIPTION
## Problem

Compaction fails on Cursor models:

```
Tool call not allowed while generating summary: cursor_context-mode_ctx_search
```

A failed compaction hard-errors the turn, so an oversized session cannot be compacted at all — the user is stuck.

## Root cause

Three verified links:

**1. The guard is opencode's.** From the opencode 1.18.11 binary (`SessionProcessor`):

```js
case "tool-input-start":
  if (a.assistantMessage.summary) throw Error(`Tool call not allowed while generating summary: ${c.name}`);
case "tool-call":
  if (a.assistantMessage.summary) throw Error(`Tool call not allowed while generating summary: ${c.name}`);
```

**2. opencode declares zero tools on that turn.** `SessionCompaction.process` builds the assistant message with `summary: true` and calls `process({ ..., tools: {}, system: [] })`. The bundled ai-sdk then drops the tool fields entirely — an empty tool record short-circuits before `activeTools` filtering:

```js
function K1(K){ return K != null && Object.keys(K).length > 0 }
async function Q1({tools:K, toolChoice:Q, activeTools:Y}){ if(!K1(K)) return { tools: void 0, toolChoice: void 0 }; ... }
```

So the provider receives `options.tools === undefined`.

**3. The provider never looked.** `grep -rn "\.tools\b|toolChoice|activeTools" src/` returned nothing before this change. Every turn ran the Cursor agent with its full native toolset, and `cursorEventsToStream` mapped that activity to provider-executed parts in the default `"blocks"` mode. The `cursor_`-prefixed generic name matches the reported `cursor_context-mode_ctx_search` exactly.

**Chain:** opencode declares no tools → Cursor agent uses its own tools anyway → provider forwards them as `tool-input-start`/`tool-call` → opencode's summary guard throws → compaction fails.

### Why not restrict tools on the Cursor run instead

`AgentOptions`, `LocalAgentOptions`, and `LocalSendOptions` in `@cursor/sdk@1.0.24` have no tool allowlist, denylist, or tool-disable field. `mode: "plan"` restricts writes but not reads/search. The only `tools?: string[]` in the package is a message field, not a run control. Suppression has to happen at the mapping boundary this plugin owns.

## Fix

Honor the host's declared tool set. If opencode offered no tools, it cannot accept tool parts — so route that turn through the **already existing and already tested** `toolDisplay: "reasoning"` path, which renders Cursor's activity as reasoning text.

| Turn | `options.tools` | Effective `toolDisplay` |
|---|---|---|
| Normal chat / subagent | non-empty array | configured value (default `blocks`) — unchanged |
| Compaction / summary | `undefined` | `reasoning` |
| Title generation | `undefined` | `reasoning` |
| `activeTools` filters everything out | `[]` | `reasoning` |

The empty-array row matters: ai-sdk's early return only covers a null tool set, so a non-empty `tools` narrowed by `activeTools` arrives as `[]`.

No new config knob, no env var, no changes to MCP forwarding, session pooling, or the skills mirror.

## Why it surfaced now

Not a code regression in 0.7.1-next.0, but that release is what switched the failing path on. opencode merges the plugin's config-channel entry over its models.dev entry; Cursor models are absent from models.dev, so the fallback applies:

```js
limit: { context: C.limit?.context ?? _?.limit?.context ?? 0, ... }
```

and auto-compaction is gated on exactly that value:

```js
if (e.model.limit.context === 0) return !1;
```

`git show be7a36e^:src/model-discovery.ts | grep limit` → no matches. Pre-#89 the config channel carried no `limit`, so `context` resolved to `0` and auto-compaction could never fire for a Cursor model. #89 published real windows, so it now does.

Manual `/compact` has no such gate and was affected all along.

## Compaction with an agent-backed provider

Worth recording, since Cursor keeps its own server-side conversation state: opencode-side compaction is genuinely effective here, and the existing pool design already produces the right lifecycle.

- The summary turn has `system: []`, so `classifyTurn` returns `side-call` → fresh ephemeral agent, pool untouched.
- The next real turn has collapsed history, so `isStrictPrefix` fails → `divergence` → `resumeAgentId` is never set → a fresh agent is seeded with the **compacted** transcript and re-pooled.

So the bloated Cursor agent is retired and context genuinely shrinks. The only thing that was broken is the tool-part leak on the summary turn.

## Tests

507 → 514. Every new test was mutation-checked, not merely observed green:

- Revert both call sites to `this.config.toolDisplay` → the 2 no-tools regression tests fail.
- Gut the reasoning fold (tool parts suppressed but nothing emitted) → only the new **positive** assertions fail (`expected '' to contain 'context-mode_ctx_search'`), confirming they test the fold rather than mere absence.
- Drop `|| tools.length === 0` → the empty-array unit test fails.

Coverage: 4 unit tests for `effectiveToolDisplay`; a no-tools `doStream` emits none of `tool-input-start`/`tool-input-delta`/`tool-input-end`/`tool-call`/`tool-result` **and** folds the activity into reasoning while the summary text still reaches the host; a with-tools `doStream` still emits `tool-call` (positive control against silently killing normal tool blocks); a no-tools `doGenerate` mirror.

## Verification

`npx tsc --noEmit` clean · `npx vitest run` 514 passed (35 files) · `npm run build` succeeds.

## Not included

The `EXC_GUARD` / guarded-fd process kill observed shortly after a compaction is **not** addressed here and is not yet attributed to this plugin. A userland double-close cannot produce that signature — probed directly on Bun 1.3.5 and Node, where double `close` on file, socket, and stdio fds all yield `EBADF`, never `EXC_GUARD` — so it originates in native code, and the crash frames are unsymbolized. Investigation and its defensive hardening are deliberately held back rather than shipped on a guess.
