### PR TITLE
chore(deps-dev): bump dev-dependencies group with 4 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "semver": "^7.8.4"
       },
       "devDependencies": {
-        "@ai-sdk/provider": "^3.0.13",
-        "@opencode-ai/sdk": "^1.18.4",
-        "@types/node": "^26.0.0",
-        "@types/semver": "^7.7.1",
+        "@ai-sdk/provider": "^3.0.15",
+        "@opencode-ai/sdk": "^1.18.18",
+        "@types/node": "^26.2.0",
+        "@types/semver": "^7.8.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
-      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.15.tgz",
+      "integrity": "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1627,9 +1627,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1637,9 +1637,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -72,10 +72,10 @@
     "@ai-sdk/provider": "^3.0.0"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^3.0.13",
-    "@opencode-ai/sdk": "^1.18.4",
-    "@types/node": "^26.0.0",
-    "@types/semver": "^7.7.1",
+    "@ai-sdk/provider": "^3.0.15",
+    "@opencode-ai/sdk": "^1.18.18",
+    "@types/node": "^26.2.0",
+    "@types/semver": "^7.8.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"


### PR DESCRIPTION
Replaces dependabot PR #98 (closed by dependabot as updatable in another way). Bumps the same four dev dependencies; notably aligns `@opencode-ai/sdk` with `@opencode-ai/plugin` 1.18.18 merged in #93 — the version skew between the two was what failed #98's typecheck (`OpencodeClient` types from two different `@opencode-ai/sdk` copies).

- `@ai-sdk/provider` 3.0.14 → 3.0.15
- `@opencode-ai/sdk` 1.18.9 → 1.18.18
- `@types/node` 26.1.2 → 26.2.0
- `@types/semver` 7.7.1 → 7.8.0

Local: `npm run typecheck` clean, `npm test` 567/567 pass.