### PR TITLE
chore(deps): bump @opencode-ai/plugin and @opencode-ai/sdk to 1.18.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **Dependency bumps:** `@opencode-ai/plugin` ^1.18.4 → ^1.18.21 (deps),
+  `@opencode-ai/sdk` ^1.18.18 → ^1.18.21 (dev). Consolidates dependabot
+  PRs #105 and #106.
+
 ## [0.8.0] — 2026-08-21
 
 Live Cursor subagent activity: the `task` card behaves like a native opencode

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",
         "@cursor/sdk": "^1.0.24",
-        "@opencode-ai/plugin": "^1.18.4",
+        "@opencode-ai/plugin": "^1.18.21",
         "semver": "^7.8.4"
       },
       "devDependencies": {
         "@ai-sdk/provider": "^3.0.15",
-        "@opencode-ai/sdk": "^1.18.18",
+        "@opencode-ai/sdk": "^1.18.21",
         "@types/node": "^26.2.0",
         "@types/semver": "^7.8.0",
         "tsup": "^8.5.1",
@@ -778,13 +778,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.18",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.18.tgz",
-      "integrity": "sha512-vqQeqJtn9c+J+tIQDzYk88xip/NVNN1hym1ATmckxo6zINHAoXoul4Sw/jgnvL00rLsfAvhja28qax4h3g/5Jg==",
+      "version": "1.18.21",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.21.tgz",
+      "integrity": "sha512-wQXMbSvg3pG75F8fYAiJxYuyr6Cl9Hd74lSCY2yznZnejpwa+ksd2kMphmgSo+/UgLhb2AId9KAI6dsRhprzTg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.18",
+        "@opencode-ai/sdk": "1.18.21",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.18",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.18.tgz",
-      "integrity": "sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA==",
+      "version": "1.18.21",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.21.tgz",
+      "integrity": "sha512-k6iHQ5C8wOPglk+LgFyYnst168cGMQYumgpbVoeXJ+iC1AtvwD5zmjuF8CxMze/y9G1K2bOeO6p9yRvA7eHZLA==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@connectrpc/connect-node": "^2.1.2",
     "@cursor/sdk": "^1.0.24",
-    "@opencode-ai/plugin": "^1.18.4",
+    "@opencode-ai/plugin": "^1.18.21",
     "semver": "^7.8.4"
   },
   "overrides": {
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.15",
-    "@opencode-ai/sdk": "^1.18.18",
+    "@opencode-ai/sdk": "^1.18.21",
     "@types/node": "^26.2.0",
     "@types/semver": "^7.8.0",
     "tsup": "^8.5.1",


### PR DESCRIPTION
Consolidates dependabot PRs #105 (`@opencode-ai/plugin`) and #106 (`@opencode-ai/sdk`): both bumped 1.18.18 → 1.18.21 in one pass.

**Verified locally:** typecheck ✓ · 614/614 tests ✓ · build ✓ · e2e (skipped locally, CI-gated).

Both PRs are lockfile-only bumps; this branch additionally updates the package.json ranges to `^1.18.21`. Closing #105 and #106 on merge.