### PR TITLE
chore(release): 0.9.0-next.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0-next.0] — 2026-08-26 (pre-release)
+
+The Cursor agent can now use installed opencode plugins (#104), plus
+consolidated opencode-ai dependency bumps (#107). Not yet on `latest`;
+install with `npm install @stablekernel/opencode-cursor@next` to test.
+
+- **Plugin tools bridge: other plugins' custom tools are now exposed to the
+  Cursor agent.** Custom tools from installed opencode plugins (e.g.
+  `opencode-pty`'s `pty_spawn`, `context-mode`'s `ctx_*`) are bridged to
+  Cursor via an `opencode-plugin-tools` MCP server (hand-rolled stdio
+  JSON-RPC, no MCP SDK dependency, running under Bun). Permission handling
+  mirrors opencode's `Permission.evaluate` — last matching rule wins per ask
+  pattern; a rule resolving to `ask` (which can't prompt from Cursor) or no
+  match fails closed. Controlled by `forwardPluginTools` and
+  `pluginTools.include/exclude`.
+- **Plugin-bundled skills are mirrored into `.cursor/skills/` too.** New
+  lowest-priority scan roots in `discoverSkills`: the opencode plugin cache
+  (`~/.cache/opencode/packages/`) and `skills/`/`skill/` dirs alongside
+  file-based plugins, handling npm and git plugin specs. The per-turn re-sync
+  also merges opencode's live skills inventory at the same priority. No new
+  config surface — folds into `forwardSkills`; `skills.include/exclude` and
+  permission filtering apply unchanged. Project/global skills always win on
+  duplicate ids; user-owned skills are never overwritten.
 - **Dependency bumps:** `@opencode-ai/plugin` ^1.18.4 → ^1.18.21 (deps),
   `@opencode-ai/sdk` ^1.18.18 → ^1.18.21 (dev). Consolidates dependabot
   PRs #105 and #106.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.8.0",
+  "version": "0.9.0-next.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.8.0",
+      "version": "0.9.0-next.0",
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.8.0",
+  "version": "0.9.0-next.0",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Pre-release of #104 (Cursor agent uses opencode plugins: plugin-tools bridge + plugin-bundled skills) and #107 (opencode-ai deps → 1.18.21). Bumps version to `0.9.0-next.0`, moves the changelog entries under the release section.

On merge + tag `v0.9.0-next.0`: publishes to npm `next` dist-tag and creates a GitHub pre-release; `latest`/Latest stay at 0.8.0.