### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.9.0-next.1] — 2026-08-26 (pre-release)
+## [0.9.0] — 2026-08-26
 
-Fixes the Cursor SDK's shell-parser diagnostic leaking into the opencode
-TUI prompt (#111). Still not on `latest`; install with
-`npm install @stablekernel/opencode-cursor@next` to test.
+The Cursor agent can now use installed opencode plugins (#104), their
+skills mirror into `.cursor/skills/`, and the Cursor SDK's shell-parser
+diagnostic no longer leaks into the opencode TUI prompt (#111).
+Consolidates pre-releases `0.9.0-next.0` and `0.9.0-next.1`.
 
 - **Fix: `shell-parser: tree-sitter natives are unavailable…` no longer
   appears in the TUI prompt.** `@cursor/sdk`'s bundled shell-parser emits a
@@ -23,12 +24,6 @@ TUI prompt (#111). Still not on `latest`; install with
   structured `{ev:"log", level:"warn"}` events over the JSONL protocol.
   Unrelated `console.warn` output passes through unchanged, and the message
   remains visible in opencode logs (service `opencode-cursor`).
-
-## [0.9.0-next.0] — 2026-08-26 (pre-release)
-
-The Cursor agent can now use installed opencode plugins (#104), plus
-consolidated opencode-ai dependency bumps (#107). Not yet on `latest`;
-install with `npm install @stablekernel/opencode-cursor@next` to test.
 
 - **Plugin tools bridge: other plugins' custom tools are now exposed to the
   Cursor agent.** Custom tools from installed opencode plugins (e.g.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.9.0-next.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stablekernel/opencode-cursor",
-      "version": "0.9.0-next.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@connectrpc/connect-node": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stablekernel/opencode-cursor",
-  "version": "0.9.0-next.1",
+  "version": "0.9.0",
   "description": "opencode provider plugin backed by the official Cursor SDK (@cursor/sdk) — adds a Cursor provider and lists its models",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Promotes the `0.9.0-next` track to the stable `0.9.0` release, per the user's request.

- `package.json` / `package-lock.json` → `0.9.0`
- CHANGELOG: consolidates `0.9.0-next.0` + `0.9.0-next.1` into a single `[0.9.0]` section (same shape as the `0.7.0` consolidation of `0.7.0-next.0`)

Contents: plugin tools bridge (#104), plugin-bundled skills mirroring, opencode-ai dependency bumps (#107), and the TUI shell-parser warning fix (#111).

After merge: tag `v0.9.0` → workflow publishes to npm dist-tag `latest` and creates a non-prerelease GitHub release (which becomes 'Latest', replacing v0.8.0).